### PR TITLE
Allow match_on to be passed as an argument to VCR

### DIFF
--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -34,3 +34,14 @@ def test_override_set_cassette_library_dir(tmpdir):
 
     assert os.path.exists(str(tmpdir.join('subdir2').join('test.json')))
     assert not os.path.exists(str(tmpdir.join('subdir').join('test.json')))
+
+
+def test_override_match_on(tmpdir):
+    my_vcr = vcr.VCR(match_on=['method'])
+
+    with my_vcr.use_cassette(str(tmpdir.join('test.json'))) as cass:
+        urllib2.urlopen('http://httpbin.org/')
+        urllib2.urlopen('http://httpbin.org/get')
+
+    assert len(cass) == 1
+    assert cass.play_count == 1

--- a/vcr/config.py
+++ b/vcr/config.py
@@ -8,9 +8,11 @@ class VCR(object):
     def __init__(self,
                  serializer='yaml',
                  cassette_library_dir=None,
-                 record_mode="once"):
+                 record_mode="once",
+                 match_on=None,
+                 ):
         self.serializer = serializer
-        self.match_on = ['url', 'method']
+        self.match_on = match_on if match_on != None else ['url', 'method']
         self.cassette_library_dir = cassette_library_dir
         self.serializers = {
             'yaml': yamlserializer,


### PR DESCRIPTION
The README says you can do this:

``` python
my_vcr = vcr.VCR(
    match_on = ['url', 'method']
)
```

Which wasn't quite the case in the current code hence this pull request.

I added a test for it but maybe a more direct test (without depending on the implementation of the method matching) would be better.

Also vcrpy is awesome! :)

Thanks!
