### PR TITLE
Problems in "once" mode

### DIFF
--- a/tests/integration/test_record_mode.py
+++ b/tests/integration/test_record_mode.py
@@ -32,6 +32,14 @@ def test_once_record_mode_two_times(tmpdir):
         response = urllib2.urlopen('http://httpbin.org/').read()
         response = urllib2.urlopen('http://httpbin.org/').read()
 
+def test_once_mode_three_times(tmpdir):
+    testfile = str(tmpdir.join('recordmode.yml'))
+    with vcr.use_cassette(testfile, record_mode="once"):
+	# get three same files
+        response1 = urllib2.urlopen('http://httpbin.org/').read()
+        response2 = urllib2.urlopen('http://httpbin.org/').read()
+        response2 = urllib2.urlopen('http://httpbin.org/').read()
+
 def test_new_episodes_record_mode(tmpdir):
     testfile = str(tmpdir.join('recordmode.yml'))
 


### PR DESCRIPTION
I found two bugs:
1. When I access one page two times during "once" mode, the second access is handled from cassette and not stored. During: "play" mode later, the second access is not played from the from cassette.
2. When I access one page three times in "once" mode the third access fails.

I don't have idea how to correct the problem in elegant way, so I attached only the tests.
I suggest not to lookup cassette in "once" mode.
## 

Maybe, the right way is to have configurable matcher "count", which can count same requests. 
- When the "count" matcher will be on, then the repeating requests will be considered different.
- Whe the "count" matcher wil be off, then repeating requests will be considered same.
