### PR TITLE
fix WindowsError:cannot create a file when that file already exists

### DIFF
--- a/vcr/persisters/filesystem.py
+++ b/vcr/persisters/filesystem.py
@@ -1,6 +1,6 @@
 import tempfile
 import os
-
+import platform
 
 class FilesystemPersister(object):
     @classmethod
@@ -13,7 +13,11 @@ class FilesystemPersister(object):
         fd, name = tempfile.mkstemp(dir=dirname, prefix=filename)
         with os.fdopen(fd, 'w') as fout:
             fout.write(contents)
-        os.rename(name, path)
+        if(platform.system() == "Windows"):
+            import ctypes
+            ctypes.windll.kernel32.MoveFileExW(name, path, 0x1)
+        else:
+            os.rename(name, path)
 
     @classmethod
     def write(cls, cassette_path, data):


### PR DESCRIPTION
fix WindowsError: [Error 183].
because that cannot create a file when that file already exists in window system..
issue:https://github.com/kevin1024/vcrpy/issues/42
