### PR TITLE
Nicer error when cassette doesn't contain request

### DIFF
--- a/tests/unit/test_cassettes.py
+++ b/tests/unit/test_cassettes.py
@@ -1,7 +1,7 @@
 import pytest
 import yaml
 import mock
-from vcr.cassette import Cassette
+from vcr.cassette import Cassette, UnhandledHTTPRequestError
 
 
 def test_cassette_load(tmpdir):
@@ -53,7 +53,7 @@ def test_cassette_responses_of():
 @mock.patch('vcr.cassette.requests_match', _mock_requests_match)
 def test_cassette_get_missing_response():
     a = Cassette('test')
-    with pytest.raises(KeyError):
+    with pytest.raises(UnhandledHTTPRequestError):
         a.responses_of('foo')
 
 @mock.patch('vcr.cassette.requests_match', _mock_requests_match)
@@ -61,5 +61,5 @@ def test_cassette_cant_read_same_request_twice():
     a = Cassette('test')
     a.append('foo','bar')
     a.play_response('foo')
-    with pytest.raises(KeyError):
+    with pytest.raises(UnhandledHTTPRequestError):
         a.play_response('foo')

--- a/vcr/cassette.py
+++ b/vcr/cassette.py
@@ -15,6 +15,10 @@ from .serializers import yamlserializer
 from .matchers import requests_match, url, method
 
 
+class UnhandledHTTPRequestError(Exception):
+    pass
+
+
 class Cassette(ContextDecorator):
     '''A container for recorded requests and responses'''
 
@@ -73,9 +77,10 @@ class Cassette(ContextDecorator):
                 if self.play_counts[index] == 0:
                     self.play_counts[index] += 1
                     return response
-        # I decided that a KeyError is the best exception to raise
-        # if the cassette doesn't contain the request asked for.
-        raise KeyError
+        # The cassette doesn't contain the request asked for.
+        raise UnhandledHTTPRequestError(
+            "The cassette (%r) doesn't contain the request (%r) asked for"
+                % (self._path,request))
 
     def responses_of(self, request):
         '''
@@ -89,9 +94,10 @@ class Cassette(ContextDecorator):
 
         if responses:
             return responses
-        # I decided that a KeyError is the best exception to raise
-        # if the cassette doesn't contain the request asked for.
-        raise KeyError
+        # The cassette doesn't contain the request asked for.
+        raise UnhandledHTTPRequestError(
+            "The cassette (%r) doesn't contain the request (%r) asked for"
+                % (self._path,request))
 
     def _as_dict(self):
         return {"requests": self.requests, "responses": self.responses}


### PR DESCRIPTION
Raise `UnhandledHTTPRequestError`.
Show name of cassette and request.

Sample output:

```
UnhandledHTTPRequestError: The cassette ('index.yml') doesn't contain the request (<Request (POST) 
http://192.168.4.61/collectors/custom_link/get_collector_id>) asked for
```
