### PR TITLE
Pin to requests < 2.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ python:
 install: 
   - pip install PyYAML pytest --use-mirrors
   - if [ $WITH_REQUESTS = "1.x" ] ; then pip install requests==1.2.3; fi
-  - if [ $WITH_REQUESTS = "2.x" ] ; then pip install requests; fi
+  - if [ $WITH_REQUESTS = "2.x" ] ; then pip install 'requests>2.0.0,<2.2.1'; fi
 script:  python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -39,18 +39,18 @@ basepython = python2.6
 deps =
     pytest
     PyYAML
-    requests
+    requests>2.0.0,<2.2.1
 
 [testenv:py27requests]
 basepython = python2.7
 deps =
     pytest
     PyYAML
-    requests
+    requests>2.0.0,<2.2.1
 
 [testenv:pypyrequests]
 basepython = pypy
 deps =
     pytest
     PyYAML
-    requests
+    requests>2.0.0,<2.2.1


### PR DESCRIPTION
With requests 2.2.1, getting a test failure:

```
TypeError: unbound method __init__() must be called with HTTPConnection instance 
as first argument (got HTTPSConnection instance instead)

in httplib.py:1164
```

Fixes: GH-59
