### PR TITLE
tox.ini: Add {posargs} for passing args to py.test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,14 +8,16 @@ envlist = py26, py27, pypy, py26requests, py27requests, pypyrequests, py26oldreq
 
 [testenv]
 commands =
-    python setup.py test
+    py.test {posargs}
 deps =
+    mock
     pytest
     PyYAML
 
 [testenv:py26oldrequests]
 basepython = python2.6
 deps =
+    mock
     pytest
     PyYAML
     requests==1.2.3
@@ -23,6 +25,7 @@ deps =
 [testenv:py27oldrequests]
 basepython = python2.7
 deps =
+    mock
     pytest
     PyYAML
     requests==1.2.3
@@ -30,6 +33,7 @@ deps =
 [testenv:pypyoldrequests]
 basepython = pypy
 deps =
+    mock
     pytest
     PyYAML
     requests==1.2.3
@@ -37,6 +41,7 @@ deps =
 [testenv:py26requests]
 basepython = python2.6
 deps =
+    mock
     pytest
     PyYAML
     requests
@@ -44,6 +49,7 @@ deps =
 [testenv:py27requests]
 basepython = python2.7
 deps =
+    mock
     pytest
     PyYAML
     requests
@@ -51,6 +57,7 @@ deps =
 [testenv:pypyrequests]
 basepython = pypy
 deps =
+    mock
     pytest
     PyYAML
     requests


### PR DESCRIPTION
This allows you to do stuff like:

```
tox -e py26requests,py27requests,pypyrequests -- tests/integration/test_requests.py
```

Without this, the args passed after `--` are thrown away and tox will run all of the tests.
