### PR TITLE
patch: Save requests...HTTPSConnection

### DIFF
--- a/vcr/patch.py
+++ b/vcr/patch.py
@@ -13,6 +13,7 @@ try:
     import requests.packages.urllib3.connectionpool as cpool
     _VerifiedHTTPSConnection = cpool.VerifiedHTTPSConnection
     _HTTPConnection = cpool.HTTPConnection
+    _HTTPSConnection = cpool.HTTPSConnection
 except ImportError:  # pragma: no cover
     pass
 


### PR DESCRIPTION
so that we unpatch back to the correct class in `reset()`.

It looks like we weren't saving the requests urllib3 `HTTPSConnection` and this suddenly became important with the new version of requests.

Closes #59
