### PR TITLE
Python 3: print_function

### DIFF
--- a/vcr/compat/counter.py
+++ b/vcr/compat/counter.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from operator import itemgetter
 from heapq import nlargest
 from itertools import repeat, ifilter
@@ -189,5 +190,5 @@ class Counter(dict):
 
 if __name__ == '__main__':
     import doctest
-    print doctest.testmod()
+    print(doctest.testmod())
 


### PR DESCRIPTION
Use print function if you must print, this lets us use the
library in python 3 environments.

partial: https://github.com/kevin1024/vcrpy/issues/86
