### PR TITLE
Play back requests requests on windows. fix #116

### DIFF
--- a/vcr/patch.py
+++ b/vcr/patch.py
@@ -136,6 +136,7 @@ class CassettePatcherBuilder(object):
             (cpool, 'VerifiedHTTPSConnection', VCRRequestsHTTPSConnection),
             (cpool, 'HTTPConnection', VCRRequestsHTTPConnection),
             (cpool, 'HTTPSConnection', VCRRequestsHTTPSConnection),
+            (cpool, 'is_connection_dropped', mock.Mock(return_value=False)),  # Needed on Windows only
             (cpool.HTTPConnectionPool, 'ConnectionCls', VCRRequestsHTTPConnection),
             (cpool.HTTPSConnectionPool, 'ConnectionCls', VCRRequestsHTTPSConnection),
         )


### PR DESCRIPTION
This fixes the issue in #116 in which playing back requests requests on Windows caused a crash.
