### PR TITLE
Fix version of `six` dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     author_email='me@kevinmccarthy.org',
     url='https://github.com/kevin1024/vcrpy',
     packages=find_packages(exclude=("tests*",)),
-    install_requires=['PyYAML', 'mock', 'six', 'contextlib2',
+    install_requires=['PyYAML', 'mock', 'six>=1.5', 'contextlib2',
                       'wrapt', 'backport_collections'],
     license='MIT',
     tests_require=['pytest', 'mock', 'pytest-localserver'],


### PR DESCRIPTION
`from six.moves.http_client import HTTPConnection` fails before version 1.5.0 of six. (on Python 2.7, at least.)

I had a particularly old copy of `six` in my virtualenv and ran into import errors in `vcrpy`.