### PR TITLE
Crash when cassette path contains cassette_library_dir

### DIFF
--- a/tests/unit/test_vcr.py
+++ b/tests/unit/test_vcr.py
@@ -147,6 +147,24 @@ def test_cassette_library_dir_with_decoration_and_no_explicit_path():
     function_name()
 
 
+def test_cassette_library_dir_with_decoration_and_explicit_path():
+    library_dir = '/libary_dir'
+    vcr = VCR(inject_cassette=True, cassette_library_dir=library_dir)
+    @vcr.use_cassette(path='custom_name')
+    def function_name(cassette):
+        assert cassette._path == os.path.join(library_dir, 'custom_name')
+    function_name()
+
+
+def test_cassette_library_dir_with_decoration_and_super_explicit_path():
+    library_dir = '/libary_dir'
+    vcr = VCR(inject_cassette=True, cassette_library_dir=library_dir)
+    @vcr.use_cassette(path=os.path.join(library_dir, 'custom_name'))
+    def function_name(cassette):
+        assert cassette._path == os.path.join(library_dir, 'custom_name')
+    function_name()
+
+
 def test_cassette_library_dir_with_path_transformer():
     library_dir = '/libary_dir'
     vcr = VCR(inject_cassette=True, cassette_library_dir=library_dir,

--- a/vcr/config.py
+++ b/vcr/config.py
@@ -120,6 +120,7 @@ class VCR(object):
             def add_cassette_library_dir(path):
                 if not path.startswith(cassette_library_dir):
                     return os.path.join(cassette_library_dir, path)
+                return path
             path_transformer = compose(add_cassette_library_dir, path_transformer)
         elif not func_path_generator:
             # If we don't have a library dir, use the functions


### PR DESCRIPTION
If an absolute path containing the `cassette_library_dir` is specified when using `vcr.use_cassette`, the transformer to add the cassette_library_dir will return None, resulting in a crash.
```
  File "...\vcr\persist.py", line 6, in load_cassette
    with open(cassette_path) as f:
TypeError: coercing to Unicode: need string or buffer, NoneType found
```
This adds a test for it, (and another one just testing a filename path to make sure the transformer is working,) as well as fixes the bug.