### PR TITLE
Fix issue #158

### DIFF
--- a/tests/integration/test_requests.py
+++ b/tests/integration/test_requests.py
@@ -224,9 +224,13 @@ def test_filter_post_params(tmpdir, scheme):
     This tests the issue in https://github.com/kevin1024/vcrpy/issues/158
 
     Ensure that a post request made through requests can still be filtered.
+    with vcr.use_cassette(cass_file, filter_post_data_parameters=['id']) as cass:
+        assert b'id=secret' not in cass.requests[0].body
     '''
     url = scheme + '://httpbin.org/post'
     cass_loc = str(tmpdir.join('filter_post_params.yaml'))
     with vcr.use_cassette(cass_loc, filter_post_data_parameters=['key']) as cass:
         requests.post(url, data={'key': 'value'})
+    with vcr.use_cassette(cass_loc, filter_post_data_parameters=['key']) as cass:
+        assert b'key=value' not in cass.requests[0].body
 

--- a/tests/integration/test_requests.py
+++ b/tests/integration/test_requests.py
@@ -217,3 +217,16 @@ def test_post_file(tmpdir, scheme):
         with open('tox.ini', 'rb') as f:
             new_response = requests.post(url, f).content
         assert original_response == new_response
+
+
+def test_filter_post_params(tmpdir, scheme):
+    '''
+    This tests the issue in https://github.com/kevin1024/vcrpy/issues/158
+
+    Ensure that a post request made through requests can still be filtered.
+    '''
+    url = scheme + '://httpbin.org/post'
+    cass_loc = str(tmpdir.join('filter_post_params.yaml'))
+    with vcr.use_cassette(cass_loc, filter_post_data_parameters=['key']) as cass:
+        requests.post(url, data={'key': 'value'})
+

--- a/vcr/filters.py
+++ b/vcr/filters.py
@@ -1,4 +1,4 @@
-from six import BytesIO
+from six import BytesIO, text_type
 from six.moves.urllib.parse import urlparse, urlencode, urlunparse
 try:
     from collections import OrderedDict
@@ -41,7 +41,10 @@ def remove_post_data_parameters(request, post_data_parameters_to_remove):
             request.body = json.dumps(json_data).encode('utf-8')
         else:
             post_data = OrderedDict()
-            for k, sep, v in [p.partition(b'=') for p in request.body.split(b'&')]:
+            if isinstance(request.body, text_type):
+                request.body = request.body.encode('utf-8')
+
+            for k, sep, v in (p.partition(b'=') for p in request.body.split(b'&')):
                 if k in post_data:
                     post_data[k].append(v)
                 elif len(k) > 0 and k.decode('utf-8') not in post_data_parameters_to_remove:


### PR DESCRIPTION
I've included a requests-specific test, because I couldn't reproduce the bug with just urllib and I didn't want to fiddle around with all of the other libraries.  However, the fix should apply to any library that has the same issue: sending a request with the request body in a non-binary form.  What I've done is to check if the request body is non-binary (using six's `text_type`) and if so encode it using the 'utf-8' encoding that's also used later.