### PR TITLE
[RFC] Deserialize request bodies to byte string, not text string (fixes #163).

### DIFF
--- a/tests/fixtures/py2body_cassette.yaml
+++ b/tests/fixtures/py2body_cassette.yaml
@@ -1,0 +1,16 @@
+interactions:
+- request:
+    body: x=5&y=2
+    headers:
+      Content-Length: ['7']
+      Content-Type: [application/x-www-form-urlencoded]
+      Host: [httpbin.org]
+    method: POST
+    uri: http://httpbin.org/post
+  response:
+    body: {string: !!python/unicode "{}\n"}
+    headers:
+      content-length: ['3']
+      content-type: [application/json]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/py3body_cassette.yaml
+++ b/tests/fixtures/py3body_cassette.yaml
@@ -1,0 +1,17 @@
+interactions:
+- request:
+    body: !!binary |
+      eD01Jnk9Mg==
+    headers:
+      Content-Length: ['7']
+      Content-Type: [application/x-www-form-urlencoded]
+      Host: [httpbin.org]
+    method: POST
+    uri: http://httpbin.org/post
+  response:
+    body: {string: "{}\n"}
+    headers:
+      content-length: ['3']
+      content-type: [application/json]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -27,6 +27,22 @@ def test_deserialize_new_json_cassette():
         deserialize(f.read(), jsonserializer)
 
 
+def test_deserialize_py2_yaml_cassette():
+    # A cassette generated under Python 2 stores the body as a string, but
+    # the same cassette generated under Python 3 stores it as "!!binary".
+    # Make sure we accept the Python 2 cassette, regardless of whether
+    # we're running under Python 2 or 3.
+    with open('tests/fixtures/py2body_cassette.yaml') as f:
+        (requests, responses) = deserialize(f.read(), yamlserializer)
+    assert requests[0].body == b'x=5&y=2'
+
+def test_deserialize_py3_yaml_cassette():
+    # Same as previous test, except make sure a cassette written under
+    # Python 3 works under both 2 and 3.
+    with open('tests/fixtures/py3body_cassette.yaml') as f:
+        (requests, responses) = deserialize(f.read(), yamlserializer)
+    assert requests[0].body == b'x=5&y=2'
+
 @mock.patch.object(jsonserializer.json, 'dumps',
                    side_effect=UnicodeDecodeError('utf-8', b'unicode error in serialization',
                                                   0, 10, 'blew up'))

--- a/vcr/request.py
+++ b/vcr/request.py
@@ -1,4 +1,4 @@
-from six import BytesIO, binary_type
+from six import BytesIO, text_type
 from six.moves.urllib.parse import urlparse, parse_qsl
 
 
@@ -29,11 +29,9 @@ class Request(object):
         self.uri = uri
         self._was_file = hasattr(body, 'read')
         if self._was_file:
-            self._body = body.read()
-            if not isinstance(self._body, binary_type):
-                self._body = self._body.encode('utf-8')
+            self.body = body.read()
         else:
-            self._body = body
+            self.body = body
         self.headers = {}
         for key in headers:
             self.add_header(key, headers[key])
@@ -44,6 +42,8 @@ class Request(object):
 
     @body.setter
     def body(self, value):
+        if isinstance(value, text_type):
+            value = value.encode('utf-8')
         self._body = value
 
     def add_header(self, key, value):

--- a/vcr/serialize.py
+++ b/vcr/serialize.py
@@ -42,9 +42,18 @@ def deserialize(cassette_string, serializer):
         _warn_about_old_cassette_format()
 
     requests = [Request._from_dict(r['request']) for r in data['interactions']]
-    responses = [
-        compat.convert_to_bytes(r['response']) for r in data['interactions']
-    ]
+    responses = []
+    for interaction in data['interactions']:
+        response = interaction['response']
+        try:
+            body = response['body']['string']
+        except (TypeError, KeyError):
+            # Sometimes, response is just a string.
+            pass
+        else:
+            body = compat.convert_body_to_bytes(body)
+            response['body']['string'] = body
+        responses.append(response)
     return requests, responses
 
 

--- a/vcr/serialize.py
+++ b/vcr/serialize.py
@@ -41,9 +41,13 @@ def deserialize(cassette_string, serializer):
     if _looks_like_an_old_cassette(data):
         _warn_about_old_cassette_format()
 
-    requests = [Request._from_dict(r['request']) for r in data['interactions']]
+    requests = []
     responses = []
     for interaction in data['interactions']:
+        request = Request._from_dict(interaction['request'])
+        request.body = compat.convert_body_to_bytes(request.body)
+        requests.append(request)
+
         response = interaction['response']
         try:
             body = response['body']['string']

--- a/vcr/serialize.py
+++ b/vcr/serialize.py
@@ -44,9 +44,7 @@ def deserialize(cassette_string, serializer):
     requests = []
     responses = []
     for interaction in data['interactions']:
-        request = Request._from_dict(interaction['request'])
-        request.body = compat.convert_body_to_bytes(request.body)
-        requests.append(request)
+        requests.append(Request._from_dict(interaction['request']))
 
         response = interaction['response']
         try:

--- a/vcr/serializers/compat.py
+++ b/vcr/serializers/compat.py
@@ -1,19 +1,14 @@
 import six
 
 
-def convert_to_bytes(resp):
-    resp = convert_body_to_bytes(resp)
-    return resp
-
-
 def convert_to_unicode(resp):
     resp = convert_body_to_unicode(resp)
     return resp
 
 
-def convert_body_to_bytes(resp):
+def convert_body_to_bytes(body):
     """
-    If the request body is a string, encode it to bytes (for python3 support)
+    If body is a text string, encode it to bytes (for python3 support)
 
     By default yaml serializes to utf-8 encoded bytestrings.
     When this cassette is loaded by python3, it's automatically decoded
@@ -23,18 +18,10 @@ def convert_body_to_bytes(resp):
     For more info on py3 yaml:
     http://pyyaml.org/wiki/PyYAMLDocumentation#Python3support
     """
-    try:
-        if not isinstance(resp['body']['string'], six.binary_type):
-            resp['body']['string'] = resp['body']['string'].encode('utf-8')
-    except (KeyError, TypeError, UnicodeEncodeError):
-        # The thing we were converting either wasn't a dictionary or didn't
-        # have the keys we were expecting.  Some of the tests just serialize
-        # and deserialize a string.
-
-        # Also, sometimes the thing actually is binary, so if you can't encode
-        # it, just give up.
-        pass
-    return resp
+    # Safe to assume valid UTF-8 here, since it comes from a YAML file.
+    if isinstance(body, six.text_type):
+        return body.encode('utf-8')
+    return body
 
 
 def convert_body_to_unicode(resp):


### PR DESCRIPTION
If you like this fix, please DO NOT MERGE IT yet!! There is unfinished business in my refactoring of vcr.serializers.compat: I refactored `convert_body_to_bytes()` to be cleaner and simpler, but left `convert_body_to_unicode()` as-is. I don't need it for this fix, and didn't want to waste time on it in case you reject this PR.

But if you *do* like this approach, I should finish the refactoring that I started. So please let me know!