### PR TITLE
Fix exception catching in coroutines.

### DIFF
--- a/tests/integration/test_tornado.py
+++ b/tests/integration/test_tornado.py
@@ -284,3 +284,17 @@ def test_tornado_with_decorator_use_cassette(get_client):
         http.HTTPRequest('http://www.google.com/', method='GET')
     )
     assert response.body.decode('utf-8') == "not actually google"
+
+
+@pytest.mark.gen_test
+@vcr.use_cassette(path_transformer=vcr.default_vcr.ensure_suffix('.yaml'))
+def test_tornado_exception_can_be_caught(get_client):
+    try:
+        yield get(get_client(), 'http://httpbin.org/status/500')
+    except http.HTTPError as e:
+        assert e.code == 500
+
+    try:
+        yield get(get_client(), 'http://httpbin.org/status/404')
+    except http.HTTPError as e:
+        assert e.code == 404

--- a/tests/integration/test_tornado_exception_can_be_caught.yaml
+++ b/tests/integration/test_tornado_exception_can_be_caught.yaml
@@ -1,0 +1,62 @@
+interactions:
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: http://httpbin.org/status/500
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+    - !!python/tuple
+      - Content-Length
+      - ['0']
+    - !!python/tuple
+      - Server
+      - [nginx]
+    - !!python/tuple
+      - Connection
+      - [close]
+    - !!python/tuple
+      - Access-Control-Allow-Credentials
+      - ['true']
+    - !!python/tuple
+      - Date
+      - ['Thu, 30 Jul 2015 17:32:39 GMT']
+    - !!python/tuple
+      - Access-Control-Allow-Origin
+      - ['*']
+    - !!python/tuple
+      - Content-Type
+      - [text/html; charset=utf-8]
+    status: {code: 500, message: INTERNAL SERVER ERROR}
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: http://httpbin.org/status/404
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+    - !!python/tuple
+      - Content-Length
+      - ['0']
+    - !!python/tuple
+      - Server
+      - [nginx]
+    - !!python/tuple
+      - Connection
+      - [close]
+    - !!python/tuple
+      - Access-Control-Allow-Credentials
+      - ['true']
+    - !!python/tuple
+      - Date
+      - ['Thu, 30 Jul 2015 17:32:39 GMT']
+    - !!python/tuple
+      - Access-Control-Allow-Origin
+      - ['*']
+    - !!python/tuple
+      - Content-Type
+      - [text/html; charset=utf-8]
+    status: {code: 404, message: NOT FOUND}
+version: 1


### PR DESCRIPTION
If you don't send exceptions back to the generator, they will raise and fail the test even if the generator is catching them at the yield point.