### PR TITLE
Capture effective url in Tornado

### DIFF
--- a/tests/integration/test_httplib2.py
+++ b/tests/integration/test_httplib2.py
@@ -56,6 +56,17 @@ def test_response_headers(scheme, tmpdir):
         resp, _ = httplib2.Http().request(url)
         assert set(headers) == set(resp.items())
 
+def test_effective_url(scheme, tmpdir):
+    '''Ensure that the effective_url is captured'''
+    url = scheme + '://httpbin.org/redirect-to?url=/html'
+    with vcr.use_cassette(str(tmpdir.join('headers.yaml'))) as cass:
+        resp, _ = httplib2.Http().request(url)
+        effective_url = resp['content-location']
+        assert effective_url == scheme + '://httpbin.org/html'
+
+    with vcr.use_cassette(str(tmpdir.join('headers.yaml'))) as cass:
+        resp, _ = httplib2.Http().request(url)
+        assert effective_url == resp['content-location']
 
 def test_multiple_requests(scheme, tmpdir):
     '''Ensure that we can cache multiple requests'''

--- a/tests/integration/test_requests.py
+++ b/tests/integration/test_requests.py
@@ -44,6 +44,15 @@ def test_body(tmpdir, scheme):
     with vcr.use_cassette(str(tmpdir.join('body.yaml'))):
         assert content == requests.get(url).content
 
+def test_effective_url(scheme, tmpdir):
+    '''Ensure that the effective_url is captured'''
+    url = scheme + '://httpbin.org/redirect-to?url=/html'
+    with vcr.use_cassette(str(tmpdir.join('url.yaml'))):
+        effective_url = requests.get(url).url
+        assert effective_url == scheme + '://httpbin.org/html'
+
+    with vcr.use_cassette(str(tmpdir.join('url.yaml'))):
+        assert effective_url == requests.get(url).url
 
 def test_auth(tmpdir, scheme):
     '''Ensure that we can handle basic auth'''

--- a/tests/integration/test_tornado.py
+++ b/tests/integration/test_tornado.py
@@ -81,6 +81,16 @@ def test_body(get_client, tmpdir, scheme):
         assert content == (yield get(get_client(), url)).body
         assert 1 == cass.play_count
 
+@pytest.mark.gen_test
+def test_effective_url(get_client, scheme, tmpdir):
+    '''Ensure that the effective_url is captured'''
+    url = scheme + '://httpbin.org/redirect-to?url=/html'
+    with vcr.use_cassette(str(tmpdir.join('url.yaml'))):
+        effective_url = (yield get(get_client(), url)).effective_url
+
+    with vcr.use_cassette(str(tmpdir.join('url.yaml'))) as cass:
+        assert effective_url == (yield get(get_client(), url)).effective_url
+        assert 1 == cass.play_count
 
 @pytest.mark.gen_test
 def test_auth(get_client, tmpdir, scheme):

--- a/tests/integration/test_tornado.py
+++ b/tests/integration/test_tornado.py
@@ -87,6 +87,7 @@ def test_effective_url(get_client, scheme, tmpdir):
     url = scheme + '://httpbin.org/redirect-to?url=/html'
     with vcr.use_cassette(str(tmpdir.join('url.yaml'))):
         effective_url = (yield get(get_client(), url)).effective_url
+        assert effective_url == scheme + '://httpbin.org/html'
 
     with vcr.use_cassette(str(tmpdir.join('url.yaml'))) as cass:
         assert effective_url == (yield get(get_client(), url)).effective_url

--- a/tests/integration/test_urllib2.py
+++ b/tests/integration/test_urllib2.py
@@ -49,6 +49,15 @@ def test_response_headers(scheme, tmpdir):
         open2 = urlopen(url).info().items()
         assert sorted(open1) == sorted(open2)
 
+def test_effective_url(scheme, tmpdir):
+    '''Ensure that the effective_url is captured'''
+    url = scheme + '://httpbin.org/redirect-to?url=/html'
+    with vcr.use_cassette(str(tmpdir.join('headers.yaml'))) as cass:
+        effective_url = urlopen(url).geturl()
+        assert effective_url == scheme + '://httpbin.org/html'
+
+    with vcr.use_cassette(str(tmpdir.join('headers.yaml'))) as cass:
+        assert effective_url == urlopen(url).geturl()
 
 def test_multiple_requests(scheme, tmpdir):
     '''Ensure that we can cache multiple requests'''

--- a/vcr/stubs/tornado_stubs.py
+++ b/vcr/stubs/tornado_stubs.py
@@ -62,6 +62,7 @@ def vcr_fetch_impl(cassette, real_fetch_impl):
                 reason=vcr_response['status']['message'],
                 headers=headers,
                 buffer=BytesIO(vcr_response['body']['string']),
+                effective_url=vcr_response.get('url'),
             )
             return callback(response)
         else:
@@ -93,6 +94,7 @@ def vcr_fetch_impl(cassette, real_fetch_impl):
                     },
                     'headers': headers,
                     'body': {'string': response.body},
+                    'url': response.effective_url,
                 }
                 cassette.append(vcr_request, vcr_response)
                 return callback(response)


### PR DESCRIPTION
Most of the libraries capture redirects in multiple requests, but tornado doesn't. This PR adds the 'url' property to the response keep the `.effective_url`.

Probably it would be more in line with the other libraries to capture all the responses separately to also populate the `.history` of the response.

I've also added some tests to other libraries, but they don't have this issue.