### PR TITLE
Mock json.dumps in test rather than decorator.

### DIFF
--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -77,9 +77,9 @@ def test_deserialize_py2py3_yaml_cassette(tmpdir, req_body, expect):
     assert requests[0].body == expect
 
 
-@mock.patch.object(jsonserializer.json, 'dumps',
-                   side_effect=UnicodeDecodeError('utf-8', b'unicode error in serialization',
-                                                  0, 10, 'blew up'))
-def test_serialize_constructs_UnicodeDecodeError(mock_dumps):
-    with pytest.raises(UnicodeDecodeError):
-        jsonserializer.serialize({})
+def test_serialize_constructs_UnicodeDecodeError():
+    exc = UnicodeDecodeError('utf-8', b'unicode error in serialization',
+                             0, 10, 'blew up')
+    with mock.patch.object(jsonserializer.json, 'dumps', side_effect=exc):
+        with pytest.raises(type(exc)):
+            jsonserializer.serialize({})


### PR DESCRIPTION
I don't run into this presently on master, but with some other local changes I
see this happening:

```
_______ ERROR at setup of test_serialize_constructs_UnicodeDecodeError _______
file /home/aron/src/pp/vcrpy/tests/unit/test_serialize.py, line 80
          @wraps(func)
          def patched(*args, **keywargs):
        fixture 'mock_dumps' not found
        available fixtures: capsys, capfd, recwarn, monkeypatch, pytestconfig, smtpserver, httpsserver, httpserver, tmpdir
        use 'py.test --fixtures [testpath]' for help on them.

/home/aron/src/pp/vcrpy/tests/unit/test_serialize.py:80
```

It seems like there's a potential for conflict between py.test and the mock
decorator, and it's an easy fix to move the mock inside the test.