### PR TITLE
Enable header replacement rather than removal

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -163,6 +163,39 @@ of post data parameters to filter.
     with my_vcr.use_cassette('test.yml', filter_post_data_parameters=['client_secret']):
         requests.post('http://api.com/postdata', data={'api_key': 'secretstring'})
 
+Advanced use of filter_headers, filter_query_parameters and filter_post_data_parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In all of the above cases, it's also possible to pass a list of ``(key, value)``
+tuples where the value can be any of the following:
+
+* A new value to replace the original value.
+* ``None`` to remove the key/value pair. (Same as passing a simple key string.)
+* A callable that returns a new value or ``None``.
+
+So these two calls are the same:
+
+.. code:: python
+
+    # original (still works)
+    vcr = VCR(filter_headers=['authorization'])
+    
+    # new
+    vcr = VCR(filter_headers=[('authorization', None)])
+
+Here are two examples of the new functionality:
+
+.. code:: python
+
+    # replace with a static value (most common)
+    vcr = VCR(filter_headers=[('authorization', 'XXXXXX')])
+    
+    # replace with a callable, for example when testing
+    # lots of different kinds of authorization.
+    def replace_auth(key, value, request):
+        auth_type = value.split(' ', 1)[0]
+        return '{} {}'.format(auth_type, 'XXXXXX')
+
 Custom Request filtering
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/vcr/config.py
+++ b/vcr/config.py
@@ -199,22 +199,28 @@ class VCR(object):
             'ignore_localhost', self.ignore_localhost
         )
         if filter_headers:
+            replacements = [h if isinstance(h, tuple) else (h, None)
+                            for h in filter_headers]
             filter_functions.append(
                 functools.partial(
-                    filters.remove_headers,
-                    headers_to_remove=filter_headers
+                    filters.replace_headers,
+                    replacements=replacements,
                 )
             )
         if filter_query_parameters:
+            replacements = [p if isinstance(p, tuple) else (p, None)
+                            for p in filter_query_parameters]
             filter_functions.append(functools.partial(
-                filters.remove_query_parameters,
-               query_parameters_to_remove=filter_query_parameters
+                filters.replace_query_parameters,
+                replacements=replacements,
             ))
         if filter_post_data_parameters:
+            replacements = [p if isinstance(p, tuple) else (p, None)
+                            for p in filter_post_data_parameters]
             filter_functions.append(
                 functools.partial(
-                    filters.remove_post_data_parameters,
-                    post_data_parameters_to_remove=filter_post_data_parameters
+                    filters.replace_post_data_parameters,
+                    replacements=replacements,
                 )
             )
 


### PR DESCRIPTION
This PR enables replacing values in the three filter functions: `filter_headers`, `filter_query_parameters` and `filter_post_parameters`. Traditionally the caller would pass a list of keys, and that API continues to work for convenience and compatibility. However it's also possible to pass a list of `(key, value)` tuples where the value can be any of the following:

* A new value to replace the header.
* `None` to remove the header.
* A callable that returns a new value or `None`.

So these two calls are the same:
```python
# original (still works)
vcr = VCR(filter_headers=['authorization'])

# new
vcr = VCR(filter_headers=[('authorization', None)])
```

Here are two examples of the new functionality:
```python
# replace with a static value (most common)
vcr = VCR(filter_headers=[('authorization', 'XXXXXX')])

# replace with a callable, for example when testing
# lots of different kinds of authorization.
def replace_auth(key, value, request):
    auth_type = value.split(' ', 1)[0]
    return '{} {}'.format(auth_type, 'XXXXXX')
```

Justification: In my test traces, I prefer to elide headers rather than remove them. For example, if the `Authorization` header is present, I'd rather give it a dummy value than remove it entirely, to prevent a future request that lacks the header from accidentally matching. Additionally this makes for easier human inspection of the traces.

This PR includes full tests for all the new and old functionality.