### PR TITLE
Attributes set on VCRConnection now also get set on the real_connection

### DIFF
--- a/tests/unit/test_stubs.py
+++ b/tests/unit/test_stubs.py
@@ -1,0 +1,7 @@
+from vcr.stubs import VCRHTTPSConnection
+
+class TestVCRConnection(object):
+    def test_setting_of_attributes_get_propogated_to_real_connection(self):
+        vcr_connection = VCRHTTPSConnection('www.examplehost.com')
+        vcr_connection.ssl_version = 'example_ssl_version'
+        assert vcr_connection.real_connection.ssl_version == 'example_ssl_version'

--- a/vcr/stubs/__init__.py
+++ b/vcr/stubs/__init__.py
@@ -323,10 +323,15 @@ class VCRConnection(object):
         For example, urllib3 will set certain attributes on the connection,
         such as 'ssl_version'. These attributes need to get set on the real
         connection to have the correct and expected behavior.
+
+        TODO: Separately setting the attribute on the two instances is not
+        ideal. We should switch to a proxying implementation.
         """
         try:
             setattr(self.real_connection, name, value)
-        except AttributeError: # raised if real_connection has not been set yet
+        except AttributeError:
+             # raised if real_connection has not been set yet, such as when
+             # we're setting the real_connection itself for the first time
             pass
 
         super(VCRConnection, self).__setattr__(name, value)

--- a/vcr/stubs/__init__.py
+++ b/vcr/stubs/__init__.py
@@ -315,6 +315,22 @@ class VCRConnection(object):
         with force_reset():
             self.real_connection = self._baseclass(*args, **kwargs)
 
+    def __setattr__(self, name, value):
+        """
+        We need to define this because any attributes that are set on the
+        VCRConnection need to be propogated to the real connection.
+
+        For example, urllib3 will set certain attributes on the connection,
+        such as 'ssl_version'. These attributes need to get set on the real
+        connection to have the correct and expected behavior.
+        """
+        try:
+            setattr(self.real_connection, name, value)
+        except AttributeError: # raised if real_connection has not been set yet
+            pass
+
+        super(VCRConnection, self).__setattr__(name, value)
+
 
 class VCRHTTPConnection(VCRConnection):
     '''A Mocked class for HTTP requests'''


### PR DESCRIPTION
**tl;dr This PR fixes VCRConnection such that attributes that get set on it also get set on the real connection, so urllib3 and requests don't break.**

I encountered an interesting issue when using VCR with HTTP requests in the requests library. When making the requests, I needed to set the SSL version (let's just say the server was weirdly quirky). This worked without VCR, but the instant I added VCR, it broke.

After some investigation, I discovered that urllib3 sets an attribute called `ssl_version` on the connection after the connection has been initialized [1]. Since with VCR the connection was a VCRHTTPSConnection, setting `ssl_version` had no effect, since when `self.real_connection.request` [2] was invoked, the `real_connection` did not have the `ssl_version` set.

[1] https://github.com/shazow/urllib3/blob/29888d0ce3e5090d5f6230890ae6f7d3a53594e3/urllib3/connectionpool.py#L724
[2] https://github.com/kevin1024/vcrpy/blob/34252bc23411e740a5baad3254668111a9930953/vcr/stubs/__init__.py#L251

This PR adds `__setattr__` so any attribute set is also set on the underlying `real_connection`, since this is probably the expected behavior. I wasn't sure where to put the test, so I created a new test file. Let me know if you'd like the test to go somewhere else.