### PR TITLE
Avoid force_reset to make patching thread-safe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class PyTest(TestCommand):
         sys.exit(errno)
 
 
-install_requires = ['PyYAML', 'wrapt', 'six>=1.5']
+install_requires = ['PyYAML', 'wrapt', 'six>=1.5', 'byteplay']
 
 
 extras_require = {

--- a/vcr/stubs/__init__.py
+++ b/vcr/stubs/__init__.py
@@ -244,16 +244,12 @@ class VCRConnection(object):
                     self._vcr_request
                 )
             )
-            # This is imported here to avoid circular import.
-            # TODO(@IvanMalison): Refactor to allow normal import.
-            from vcr.patch import force_reset
-            with force_reset():
-                self.real_connection.request(
-                    method=self._vcr_request.method,
-                    url=self._url(self._vcr_request.uri),
-                    body=self._vcr_request.body,
-                    headers=self._vcr_request.headers,
-                )
+            self.real_connection.request(
+                method=self._vcr_request.method,
+                url=self._url(self._vcr_request.uri),
+                body=self._vcr_request.body,
+                headers=self._vcr_request.headers,
+            )
 
             # get the response
             response = self.real_connection.getresponse()
@@ -308,12 +304,7 @@ class VCRConnection(object):
         if six.PY3:
             kwargs.pop('strict', None) # apparently this is gone in py3
 
-        # need to temporarily reset here because the real connection
-        # inherits from the thing that we are mocking out.  Take out
-        # the reset if you want to see what I mean :)
-        from vcr.patch import force_reset
-        with force_reset():
-            self.real_connection = self._baseclass(*args, **kwargs)
+        self.real_connection = self._baseclass(*args, **kwargs)
 
     def __setattr__(self, name, value):
         """


### PR DESCRIPTION
Before, `force_reset` was used twice when instantiating the original baseclasses. It was necessary to unpatch things, since the classes were subclasses of patched classes *and* because the subclass referred to the super class explicitly by name.

That is, `httplib` has code like:
```python
class HTTPConnection:
    ...

class HTTPSConnection(HTTPConnection):
    "This class allows communication via SSL."

    def __init__(self, host, port=None, ...):
        HTTPConnection.__init__(self, host, port, ...)
```
Creating a real `HTTPSConnection` instance is now impossible as long as `httplib.HTTPConnection` is patched.

To get around this, `force_reset` was used to temporary unpatch things. However, this means modifying global state and is thus not thread-safe. Modifying the classes once when vcr is loaded is better since no further patching and unpatching needs to be done after that.

This code in this commit uses byteplay, which is not Python 3 compatible. I think byteplay could be upsed with Python 3 compatibility, but I haven't looked much into it. The project also seems semi-abandoned with the last release done in 2010.

Also, I will agree that this kind of bytecode level patching is at best controversial :-) However, since I only use it to fix a reference to a super-class, I think it could be acceptable here.

Fixes #212 and makes the test program there run stable.