### PR TITLE
Fix use_cassette when used as decorator does not return the wrapped function's return value

### DIFF
--- a/tests/unit/test_vcr.py
+++ b/tests/unit/test_vcr.py
@@ -301,6 +301,17 @@ def test_additional_matchers():
     function_additional()
 
 
+def test_decoration_should_respect_function_return_value():
+    vcr = VCR()
+    ret = 'a-return-value'
+
+    @vcr.use_cassette
+    def function_with_return():
+        return ret
+
+    assert ret == function_with_return()
+
+
 class TestVCRClass(VCR().test_case()):
 
     def no_decoration(self):

--- a/vcr/cassette.py
+++ b/vcr/cassette.py
@@ -127,7 +127,7 @@ class CassetteContextDecorator(object):
 
     def _handle_function(self, function, args, kwargs):
         with self as cassette:
-            self.__handle_function(cassette, function, args, kwargs)
+            return self.__handle_function(cassette, function, args, kwargs)
 
     @staticmethod
     def get_function_name(function):


### PR DESCRIPTION
`CassetteContextDecorator._handle_function` should return the value back to caller.

Let me know if the test is good enough or not, thanks.