### PR TITLE
Fallback to importing from urllib3

### DIFF
--- a/vcr/stubs/requests_stubs.py
+++ b/vcr/stubs/requests_stubs.py
@@ -1,6 +1,10 @@
 '''Stubs for requests'''
 
-from requests.packages.urllib3.connectionpool import HTTPConnection, VerifiedHTTPSConnection
+try:
+    from requests.packages.urllib3.connectionpool import HTTPConnection, VerifiedHTTPSConnection
+except ImportError:
+    from urllib3.connectionpool import HTTPConnection, VerifiedHTTPSConnection
+
 from ..stubs import VCRHTTPConnection, VCRHTTPSConnection
 
 # urllib3 defines its own HTTPConnection classes, which requests goes ahead and assumes


### PR DESCRIPTION
requests.packages.urllib3 may be literally urllib3
instead of vendored urllib3.

Fixes #215.