### PR TITLE
Fix for Serialization errors with JSON adapter

### DIFF
--- a/vcr/serialize.py
+++ b/vcr/serialize.py
@@ -50,7 +50,7 @@ def deserialize(cassette_string, serializer):
 
 def serialize(cassette_dict, serializer):
     interactions = ([{
-        'request': request._to_dict(),
+        'request': compat.convert_to_unicode(request._to_dict()),
         'response': compat.convert_to_unicode(response),
     } for request, response in zip(
         cassette_dict['requests'],

--- a/vcr/serializers/jsonserializer.py
+++ b/vcr/serializers/jsonserializer.py
@@ -9,16 +9,21 @@ def deserialize(cassette_string):
 
 
 def serialize(cassette_dict):
+    error_message = (
+        "Does this HTTP interaction contain binary data? "
+        "If so, use a different serializer (like the yaml serializer) "
+        "for this request?"
+    )
+
     try:
         return json.dumps(cassette_dict, indent=4)
-    except UnicodeDecodeError as original:
+    except UnicodeDecodeError as original: # py2
         raise UnicodeDecodeError(
             original.encoding,
             b"Error serializing cassette to JSON",
             original.start,
             original.end,
-            original.args[-1] +
-            ("Does this HTTP interaction contain binary data? "
-             "If so, use a different serializer (like the yaml serializer) "
-             "for this request?")
+            original.args[-1] + error_message
         )
+    except TypeError as original: # py3
+        raise TypeError(error_message)


### PR DESCRIPTION
Hi!

Here is first attemp to fix the issue #222.
It might be not perfect (specially the `jsonserializer.py` part :flushed:) but if general idea seems reasonable I could update it according to comments.

So the idea itself to try to serialize `request body` as well as `response body` because in`py3` its string representation could be binary that leads to an error described in issue #222.

See you!

