### PR TITLE
Run flake8 on all environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,4 +42,5 @@ install:
 script:
 - v=$TRAVIS_PYTHON_VERSION
 - if [[ ${v%py} != $v ]]; then TOXPY=$v; else TOXPY=py"${v/./}"; fi
-- tox -e "${TOXPY}-${TOX_SUFFIX}"
+- if [[ $TOX_SUFFIX != flakes ]]; then tox -e "${TOXPY}-${TOX_SUFFIX}" ; fi
+- if [[ $TOX_SUFFIX == flakes ]]; then tox -e "${TOX_SUFFIX}" ; fi

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
-envlist = py34-flakes,{py26,py27,py33,py34,pypy}-{requests27,requests26,requests25,requests24,requests23,requests22,requests1,httplib2,urllib317,urllib319,urllib3110,tornado,boto}
+envlist = {py26,py27,py33,py34,pypy}-{flakes,requests27,requests26,requests25,requests24,requests23,requests22,requests1,httplib2,urllib317,urllib319,urllib3110,tornado,boto}
 
-[testenv:py34-flakes]
+[testenv:flakes]
 skipsdist = True
+basepython = python
 commands =
+    flake8 --version
     flake8 --exclude="./docs/conf.py"
     pyflakes ./docs/conf.py
 deps = flake8


### PR DESCRIPTION
dc9cd422 introduced Travis checking of flakes using tox.
However tox.ini only defined 'flakes-py34', so Travis
was only invoking flake8 on Python 3.4, and invoking
py.test on other Python versions.

As tox factors only work properly on the default `testenv`,
use a generic tox environment 'flakes' which uses the
default Python version, which Travis will set.