### PR TITLE
Add record_on_exception flag. Addresses #205.

### DIFF
--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -56,3 +56,23 @@ def test_missing_matcher():
     with pytest.raises(KeyError):
         with my_vcr.use_cassette("test.yaml", match_on=['notawesome']):
             pass
+
+
+def test_dont_record_on_exception(tmpdir):
+    my_vcr = vcr.VCR(record_on_exception=False)
+
+    @my_vcr.use_cassette(str(tmpdir.join('dontsave.yml')))
+    def some_test():
+        assert 'Not in content' in urlopen('http://httpbin.org/get')
+
+    with pytest.raises(AssertionError):
+        some_test()
+
+    assert not os.path.exists(str(tmpdir.join('dontsave.yml')))
+
+    # Make sure context decorator has the same behavior
+    with pytest.raises(AssertionError):
+        with my_vcr.use_cassette(str(tmpdir.join('dontsave2.yml'))):
+            assert 'Not in content' in urlopen('http://httpbin.org/get').read()
+
+    assert not os.path.exists(str(tmpdir.join('dontsave2.yml')))

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -63,7 +63,7 @@ def test_dont_record_on_exception(tmpdir):
 
     @my_vcr.use_cassette(str(tmpdir.join('dontsave.yml')))
     def some_test():
-        assert 'Not in content' in urlopen('http://httpbin.org/get')
+        assert b'Not in content' in urlopen('http://httpbin.org/get')
 
     with pytest.raises(AssertionError):
         some_test()
@@ -73,6 +73,6 @@ def test_dont_record_on_exception(tmpdir):
     # Make sure context decorator has the same behavior
     with pytest.raises(AssertionError):
         with my_vcr.use_cassette(str(tmpdir.join('dontsave2.yml'))):
-            assert 'Not in content' in urlopen('http://httpbin.org/get').read()
+            assert b'Not in content' in urlopen('http://httpbin.org/get').read()
 
     assert not os.path.exists(str(tmpdir.join('dontsave2.yml')))

--- a/vcr/cassette.py
+++ b/vcr/cassette.py
@@ -34,7 +34,9 @@ class CassetteContextDecorator(object):
     this class as a context manager in ``__exit__``.
     """
 
-    _non_cassette_arguments = ('path_transformer', 'func_path_generator')
+    _non_cassette_arguments = (
+        'path_transformer', 'func_path_generator', 'record_on_exception',
+    )
 
     @classmethod
     def from_args(cls, cassette_class, **kwargs):
@@ -81,8 +83,13 @@ class CassetteContextDecorator(object):
         self.__finish = self._patch_generator(self.cls.load(**cassette_kwargs))
         return next(self.__finish)
 
-    def __exit__(self, *args):
-        next(self.__finish, None)
+    def __exit__(self, *exc_info):
+        exception_was_raised = any(exc_info)
+        record_on_exception = self._args_getter().get(
+            'record_on_exception', True
+        )
+        if record_on_exception or not exception_was_raised:
+            next(self.__finish, None)
         self.__finish = None
 
     @wrapt.decorator

--- a/vcr/config.py
+++ b/vcr/config.py
@@ -35,7 +35,8 @@ class VCR(object):
                  before_record_response=None, filter_post_data_parameters=(),
                  match_on=('method', 'scheme', 'host', 'port', 'path', 'query'),
                  before_record=None, inject_cassette=False, serializer='yaml',
-                 cassette_library_dir=None, func_path_generator=None):
+                 cassette_library_dir=None, func_path_generator=None,
+                 record_on_exception=True):
         self.serializer = serializer
         self.match_on = match_on
         self.cassette_library_dir = cassette_library_dir
@@ -67,6 +68,7 @@ class VCR(object):
         self.inject_cassette = inject_cassette
         self.path_transformer = path_transformer
         self.func_path_generator = func_path_generator
+        self.record_on_exception = record_on_exception
         self._custom_patches = tuple(custom_patches)
 
     def _get_serializer(self, serializer_name):
@@ -120,6 +122,10 @@ class VCR(object):
             'func_path_generator',
             self.func_path_generator
         )
+        record_on_exception = kwargs.get(
+            'record_on_exception',
+            self.record_on_exception
+        )
         cassette_library_dir = kwargs.get(
             'cassette_library_dir',
             self.cassette_library_dir
@@ -152,6 +158,7 @@ class VCR(object):
             ),
             'inject': kwargs.get('inject_cassette', self.inject_cassette),
             'path_transformer': path_transformer,
+            'record_on_exception': record_on_exception,
             'func_path_generator': func_path_generator
         }
         path = kwargs.get('path')


### PR DESCRIPTION
When `record_on_exception=False`, cassettes will not be written when the decorated/context-managed code raises an uncaught exception. Defaults to `True`, which maintains historical behavior.

Did not know an appropriate place to document this so this PR includes no docs. Would be happy to add them but just couldn't decide what section of the docs was appropriate.

This change is discussed in #205.
