### PR TITLE
Use tox-travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,7 @@ python:
 - 3.4
 - pypy
 install:
-- pip install tox
+- pip install tox-travis
 - if [[ $TOX_SUFFIX != flakes ]]; then python setup.py install ; fi
 script:
-- v=$TRAVIS_PYTHON_VERSION
-- if [[ ${v%py} != $v ]]; then TOXPY=$v; else TOXPY=py"${v/./}"; fi
-- tox -e "${TOXPY}-${TOX_SUFFIX}"
+- tox -e "${TOX_SUFFIX}"

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,15 @@
 [tox]
-envlist = py34-flakes,{py26,py27,py33,py34,pypy}-{requests27,requests26,requests25,requests24,requests23,requests22,requests1,httplib2,urllib317,urllib319,urllib3110,tornado,boto}
+envlist = {py26,py27,py33,py34,pypy}-{flakes,requests27,requests26,requests25,requests24,requests23,requests22,requests1,httplib2,urllib317,urllib319,urllib3110,tornado,boto}
 
-[testenv:py34-flakes]
+[testenv:flakes]
 skipsdist = True
 commands =
+    flake8 --version
     flake8 --exclude="./docs/conf.py"
     pyflakes ./docs/conf.py
 deps = flake8
 
 [testenv]
-basepython =
-    py26: python2.6
-    py27: python2.7
-    py33: python3.3
-    py34: python3.4
-    pypy: pypy
 commands =
     py.test {posargs}
 deps =


### PR DESCRIPTION
dc9cd42 introduced Travis checking of flakes using tox.
However tox.ini only defined 'flakes-py34', so Travis
was only invoking flake8 on Python 3.4, and invoking
py.test on other Python versions.

As tox factors only work properly on the default testenv,
use a generic tox environment 'flakes', and use tox-travis
to select the correct basepython.