### PR TITLE
Exclude __pycache__ dirs & compiled files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,5 @@ include README.rst
 include LICENSE.txt
 include tox.ini
 recursive-include tests *
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]


### PR DESCRIPTION
The current vcrpy sdist on PyPI includes __pycache__ dirs and compiled files which causes tests to fail when running tests via setup.py test

import file mismatch:
imported module 'test_persist' has this __file__ attribute:
  /Users/imalison/Projects/vcrpy/tests/unit/test_persist.py
which is not the same as the test file we want to collect:
  /usr/home/user/repos/freebsd/ports/devel/py-vcrpy/work/vcrpy-1.7.4/tests/unit/test_persist.py
HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules

This change recursively excludes these directories and files from future source distributions