### PR TITLE
Avoid concatenating bytes with strings

### DIFF
--- a/tests/integration/test_boto.py
+++ b/tests/integration/test_boto.py
@@ -1,12 +1,12 @@
 import pytest
 boto = pytest.importorskip("boto")
 
-import boto
-import boto.iam
-from boto.s3.connection import S3Connection
-from boto.s3.key import Key
-from ConfigParser import DuplicateSectionError
-import vcr
+import boto  # NOQA
+import boto.iam  # NOQA
+from boto.s3.connection import S3Connection  # NOQA
+from boto.s3.key import Key  # NOQA
+from ConfigParser import DuplicateSectionError  # NOQA
+import vcr  # NOQA
 
 
 def test_boto_stubs(tmpdir):

--- a/tests/integration/test_requests.py
+++ b/tests/integration/test_requests.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 '''Test requests' interaction with vcr'''
-from io import BytesIO
-
 import pytest
 import vcr
 from assertions import assert_cassette_empty, assert_is_json
@@ -97,7 +95,7 @@ def test_post(tmpdir, scheme):
 
 
 def test_post_chunked_binary(tmpdir, scheme):
-    '''Ensure that we can send chunked binary without breaking while trying to concatenate bytes with string.'''
+    '''Ensure that we can send chunked binary without breaking while trying to concatenate bytes with str.'''
     data1 = iter([b'data', b'to', b'send'])
     data2 = iter([b'data', b'to', b'send'])
     url = scheme + '://httpbin.org/post'

--- a/tests/integration/test_requests.py
+++ b/tests/integration/test_requests.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 '''Test requests' interaction with vcr'''
+from io import BytesIO
 
 import pytest
 import vcr
@@ -91,6 +92,21 @@ def test_post(tmpdir, scheme):
 
     with vcr.use_cassette(str(tmpdir.join('requests.yaml'))):
         req2 = requests.post(url, data).content
+
+    assert req1 == req2
+
+
+def test_post_chunked_binary(tmpdir, scheme):
+    '''Ensure that we can send chunked binary without breaking while trying to concatenate bytes with string.'''
+    data1 = iter([b'data', b'to', b'send'])
+    data2 = iter([b'data', b'to', b'send'])
+    url = scheme + '://httpbin.org/post'
+    with vcr.use_cassette(str(tmpdir.join('requests.yaml'))):
+        req1 = requests.post(url, data1).content
+        print(req1)
+
+    with vcr.use_cassette(str(tmpdir.join('requests.yaml'))):
+        req2 = requests.post(url, data2).content
 
     assert req1 == req2
 

--- a/tests/integration/test_wild.py
+++ b/tests/integration/test_wild.py
@@ -3,7 +3,7 @@ from six.moves import xmlrpc_client
 
 requests = pytest.importorskip("requests")
 
-import vcr
+import vcr  # NOQA
 
 try:
     import httplib

--- a/tests/unit/test_cassettes.py
+++ b/tests/unit/test_cassettes.py
@@ -233,7 +233,8 @@ def test_cassette_use_called_without_path_uses_function_to_generate_path():
 
 
 def test_path_transformer_with_function_path():
-    path_transformer = lambda path: os.path.join('a', path)
+    def path_transformer(path):
+        return os.path.join('a', path)
 
     @Cassette.use(inject=True, path_transformer=path_transformer)
     def function_name(cassette):

--- a/vcr/stubs/__init__.py
+++ b/vcr/stubs/__init__.py
@@ -191,7 +191,8 @@ class VCRConnection(object):
         body of the request.  So if that happens, let's just append the data
         onto the most recent request in the cassette.
         '''
-        self._vcr_request.body = (self._vcr_request.body or '') + data
+        self._vcr_request.body = self._vcr_request.body + data \
+            if self._vcr_request.body else data
 
     def close(self):
         # Note: the real connection will only close if it's open, so


### PR DESCRIPTION
I stumbled upon an error while using boto and python3.5 while it tries to send chunks of data, vcrpy tries to concatenate string with bytes, because `self._vcr_request.body` is an empty `byte` it will fall on `or` which initialize an empty `str` and try to concatenate with `data` which is a byte  and it would break.