### PR TITLE
Remove pytest-localserver from test dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     install_requires=install_requires,
     extras_require=extras_require,
     license='MIT',
-    tests_require=['pytest', 'mock', 'pytest-localserver', 'pytest-httpbin'],
+    tests_require=['pytest', 'mock', 'pytest-httpbin'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
pytest-localserver is no longer needed after
the switch to using pytest-httpbin.