### PR TITLE
Fix deepcopy issue for response headers when `decode_compressed_response` is enabled

### DIFF
--- a/tests/integration/test_stubs.py
+++ b/tests/integration/test_stubs.py
@@ -68,7 +68,7 @@ def test_original_decoded_response_is_not_modified(tmpdir, httpbin):
 
     # Even though the above are raw bytes, the JSON data should have been
     # decoded and saved to the cassette.
-    with vcr.use_cassette(testfile) as cass:
+    with vcr.use_cassette(testfile):
         inside2 = urlopen(request)
         assert 'content-encoding' not in inside2.headers
         assert_is_json(inside2.read())

--- a/tests/integration/test_stubs.py
+++ b/tests/integration/test_stubs.py
@@ -1,5 +1,8 @@
 import vcr
 import six.moves.http_client as httplib
+from six.moves.urllib.request import urlopen, Request
+
+from assertions import assert_is_json
 
 
 def _headers_are_case_insensitive(host, port):
@@ -44,3 +47,28 @@ def test_multiple_headers(tmpdir, httpbin):
         inside = _multiple_header_value(httpbin)
 
     assert outside == inside
+
+
+def test_original_decoded_response_is_not_modified(tmpdir, httpbin):
+    testfile = str(tmpdir.join('decoded_response.yml'))
+    url = httpbin.url + '/gzip'
+    request = Request(url)
+    outside = urlopen(request)
+
+    with vcr.use_cassette(testfile, decode_compressed_response=True):
+        inside = urlopen(request)
+
+        # Assert that we do not modify the original response while appending
+        # to the casssette.
+        assert 'gzip' == inside.headers['content-encoding']
+
+        # They should be the same response.
+        assert inside.headers.items() == outside.headers.items()
+        assert inside.read() == outside.read()
+
+    # Even though the above are raw bytes, the JSON data should have be decoded
+    # and saved to the cassette.
+    with vcr.use_cassette(testfile) as cass:
+        inside2 = urlopen(request)
+        assert 'content-encoding' not in inside2.headers
+        assert_is_json(inside2.read())

--- a/tests/integration/test_stubs.py
+++ b/tests/integration/test_stubs.py
@@ -69,6 +69,6 @@ def test_original_decoded_response_is_not_modified(tmpdir, httpbin):
     # Even though the above are raw bytes, the JSON data should have been
     # decoded and saved to the cassette.
     with vcr.use_cassette(testfile):
-        inside2 = urlopen(request)
-        assert 'content-encoding' not in inside2.headers
-        assert_is_json(inside2.read())
+        inside = urlopen(request)
+        assert 'content-encoding' not in inside.headers
+        assert_is_json(inside.read())

--- a/tests/integration/test_stubs.py
+++ b/tests/integration/test_stubs.py
@@ -66,8 +66,8 @@ def test_original_decoded_response_is_not_modified(tmpdir, httpbin):
         assert inside.headers.items() == outside.headers.items()
         assert inside.read() == outside.read()
 
-    # Even though the above are raw bytes, the JSON data should have be decoded
-    # and saved to the cassette.
+    # Even though the above are raw bytes, the JSON data should have been
+    # decoded and saved to the cassette.
     with vcr.use_cassette(testfile) as cass:
         inside2 = urlopen(request)
         assert 'content-encoding' not in inside2.headers

--- a/vcr/filters.py
+++ b/vcr/filters.py
@@ -146,9 +146,9 @@ def decode_response(response):
         else:  # encoding == 'deflate'
             return zlib.decompress(body)
 
+    response = copy.deepcopy(response)
     headers = CaseInsensitiveDict(response['headers'])
     if is_compressed(headers):
-        response = copy.deepcopy(response)
         encoding = headers['content-encoding'][0]
         headers['content-encoding'].remove(encoding)
         if not headers['content-encoding']:

--- a/vcr/filters.py
+++ b/vcr/filters.py
@@ -146,6 +146,8 @@ def decode_response(response):
         else:  # encoding == 'deflate'
             return zlib.decompress(body)
 
+    # Deepcopy here in case headers contain lists and other objects that could
+    # be mutated by a shallow copy.
     response = copy.deepcopy(response)
     headers = CaseInsensitiveDict(response['headers'])
     if is_compressed(headers):

--- a/vcr/filters.py
+++ b/vcr/filters.py
@@ -146,8 +146,8 @@ def decode_response(response):
         else:  # encoding == 'deflate'
             return zlib.decompress(body)
 
-    # Deepcopy here in case headers contain lists and other objects that could
-    # be mutated by a shallow copy.
+    # Deepcopy here in case `headers` contain objects that could
+    # be mutated by a shallow copy and corrupt the real response.
     response = copy.deepcopy(response)
     headers = CaseInsensitiveDict(response['headers'])
     if is_compressed(headers):


### PR DESCRIPTION
Hi @kevin1024 and @IvanMalison,

I ran into this issue after the 1.8.0 release where the first time I would request gzipped data inside a cassette context, my test would fail with a JSON deserialization issue.

I narrowed down the problem to be the data being returned by the stub would not have content encoding set as gzip but the content was not decoded (as the original response should not be modified), so `requests` was failing when I would call `.json()`.

In the filter to decode gzipped data, `headers` is a reference to the original response headers`gzip` is in a list and therefore being shallow copied in the `__init__` of `util.CaseInsensitiveDict`.

Looking forward to your feedback. Cheers!

(Aside: after going through some of the cassette code, I think a better place for the `self._before_record_request` and `self._before_record_response` calls would be in `_save` so `append` doesn't have side-effects. If you think so too happy to send this over in a separate PR.)