### PR TITLE
fix tests in stubs, requests ssl verification and httpbin+flask

### DIFF
--- a/tests/integration/test_stubs.py
+++ b/tests/integration/test_stubs.py
@@ -66,7 +66,9 @@ def test_original_decoded_response_is_not_modified(tmpdir, httpbin):
         assert 'gzip' == inside.headers['content-encoding']
 
         # They should effectively be the same response.
-        assert inside.headers.items() == outside.getheaders()
+        inside_headers = (h for h in inside.headers.items() if h[0] != 'Date')
+        outside_headers = (h for h in outside.getheaders() if h[0] != 'Date')
+        assert set(inside_headers) == set(outside_headers)
         assert inside.read() == outside.read()
 
     # Even though the above are raw bytes, the JSON data should have been

--- a/tests/integration/test_wild.py
+++ b/tests/integration/test_wild.py
@@ -76,7 +76,7 @@ def test_amazon_doctype(tmpdir):
     # amazon gzips its homepage.  For some reason, in requests 2.7, it's not
     # getting gunzipped.
     with vcr.use_cassette(str(tmpdir.join('amz.yml'))):
-        r = requests.get('http://www.amazon.com')
+        r = requests.get('http://www.amazon.com', verify=False)
     assert 'html' in r.text
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,8 @@ deps = flake8
 commands =
     ./runtests.sh {posargs}
 deps =
+    # httpbin fails with latest Flask, so we pin it
+    Flask==0.10.1
     mock
     pytest
     pytest-httpbin


### PR DESCRIPTION
assert in stubs failed because the order differs in lists
`requests` fails sometimes SSL verification, went with `verify=False`
httbin + Flask 0.11 fails, so i pinned it down

this should fix #258 