### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Source code
   https://github.com/kevin1024/vcrpy
 
 Documentation
-  https://vcrpy.readthedocs.org/
+  https://vcrpy.readthedocs.io/
 
 Rationale
 ---------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,7 +110,7 @@ todo_include_todos = False
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.
-# https://read-the-docs.readthedocs.org/en/latest/theme.html#how-do-i-use-this-locally-and-on-read-the-docs
+# https://read-the-docs.readthedocs.io/en/latest/theme.html#how-do-i-use-this-locally-and-on-read-the-docs
 if 'READTHEDOCS' not in os.environ:
     import sphinx_rtd_theme
     html_theme = 'sphinx_rtd_theme'

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -19,7 +19,7 @@ that has ``requests`` installed.
 
 Also, in order for the boto tests to run, you will need an AWS key.
 Refer to the `boto
-documentation <http://boto.readthedocs.org/en/latest/getting_started.html>`__
+documentation <https://boto.readthedocs.io/en/latest/getting_started.html>`__
 for how to set this up. I have marked the boto tests as optional in
 Travis so you don't have to worry about them failing if you submit a
 pull request.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.