### PR TITLE
VCR AttributeError: 'NoneType' object has no attribute 'encode'

### DIFF
--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -4,7 +4,7 @@ import pytest
 from vcr.compat import mock
 from vcr.request import Request
 from vcr.serialize import deserialize, serialize
-from vcr.serializers import yamlserializer, jsonserializer
+from vcr.serializers import yamlserializer, jsonserializer, compat
 
 
 def test_deserialize_old_yaml_cassette():
@@ -131,3 +131,8 @@ def test_serialize_binary_request():
         )
     except (UnicodeDecodeError, TypeError) as exc:
         assert msg in str(exc)
+
+def test_deserialize_no_body_string():
+    data = {'body': {'string': None}}
+    output = compat.convert_to_bytes(data)
+    assert data == output

--- a/vcr/serializers/compat.py
+++ b/vcr/serializers/compat.py
@@ -24,7 +24,7 @@ def convert_body_to_bytes(resp):
     http://pyyaml.org/wiki/PyYAMLDocumentation#Python3support
     """
     try:
-        if not isinstance(resp['body']['string'], six.binary_type):
+        if resp['body']['string'] is not None and not isinstance(resp['body']['string'], six.binary_type):
             resp['body']['string'] = resp['body']['string'].encode('utf-8')
     except (KeyError, TypeError, UnicodeEncodeError):
         # The thing we were converting either wasn't a dictionary or didn't


### PR DESCRIPTION
Hi,

Using an old fork but may be usefull.

I think checking the string is required like on line 47.

Best regards