### PR TITLE
Errorfix: Add missing requirement yarl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ extras_require = {
     ':python_version in "2.4, 2.5, 2.6"':
         ['contextlib2', 'backport_collections', 'mock'],
     ':python_version in "2.7, 3.1, 3.2"': ['contextlib2', 'mock'],
+    ':python_version in "3.4, 3.5, 3.6"': ['yarl'],
 }
 
 


### PR DESCRIPTION
This PR fixes the following error that was introduced on vcrpy==1.10.4:

```python
    from aiohttp import ClientResponse
>   from yarl import URL
E   ImportError: No module named 'yarl'

../virtualenvs/venv-3.5.1/lib/python3.5/site-packages/vcr/stubs/aiohttp_stubs/__init__.py:9: ImportError
```