### PR TITLE
added a fix to httplib2

### DIFF
--- a/vcr/stubs/__init__.py
+++ b/vcr/stubs/__init__.py
@@ -287,7 +287,9 @@ class VCRConnection(object):
             # Cassette is write-protected, don't actually connect
             return
 
-        return self.real_connection.connect(*args, **kwargs)
+        from vcr.patch import force_reset
+        with force_reset():
+            return self.real_connection.connect(*args, **kwargs)
 
     @property
     def sock(self):


### PR DESCRIPTION
If we are doing a "real" connect, we need to `force_reset`, otherwise we get and unbound method error.