### PR TITLE
handle pytest-asyncio async def coroutines

### DIFF
--- a/tests/integration/aiohttp_utils.py
+++ b/tests/integration/aiohttp_utils.py
@@ -1,7 +1,13 @@
 import asyncio
+import aiohttp
 
 
 @asyncio.coroutine
-def aiohttp_request(session, method, url, as_text, **kwargs):
-    response = yield from session.request(method, url, **kwargs)  # NOQA: E999
-    return response, (yield from response.text()) if as_text else (yield from response.json())  # NOQA: E999
+def aiohttp_request(loop, method, url, as_text, **kwargs):
+    with aiohttp.ClientSession(loop=loop) as session:
+        response = yield from session.request(method, url, **kwargs)  # NOQA: E999
+        if as_text:
+            content = yield from response.text()  # NOQA: E999
+        else:
+            content = yield from response.json()  # NOQA: E999
+        return response, content

--- a/tests/integration/async_def.py
+++ b/tests/integration/async_def.py
@@ -1,0 +1,13 @@
+import aiohttp
+import pytest
+import vcr
+
+
+@vcr.use_cassette()
+@pytest.mark.asyncio
+async def test_http():  # noqa: E999
+    async with aiohttp.ClientSession() as session:
+        url = 'https://httpbin.org/get'
+        params = {'ham': 'spam'}
+        resp = await session.get(url, params=params)  # noqa: E999
+        assert (await resp.json())['args'] == {'ham': 'spam'}  # noqa: E999

--- a/tests/integration/test_http
+++ b/tests/integration/test_http
@@ -1,0 +1,22 @@
+interactions:
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://httpbin.org/get?ham=spam
+  response:
+    body: {string: "{\n  \"args\": {\n    \"ham\": \"spam\"\n  }, \n  \"headers\"\
+        : {\n    \"Accept\": \"*/*\", \n    \"Accept-Encoding\": \"gzip, deflate\"\
+        , \n    \"Connection\": \"close\", \n    \"Host\": \"httpbin.org\", \n   \
+        \ \"User-Agent\": \"Python/3.5 aiohttp/2.0.1\"\n  }, \n  \"origin\": \"213.86.221.35\"\
+        , \n  \"url\": \"https://httpbin.org/get?ham=spam\"\n}\n"}
+    headers: {Access-Control-Allow-Credentials: 'true', Access-Control-Allow-Origin: '*',
+      Connection: keep-alive, Content-Length: '299', Content-Type: application/json,
+      Date: 'Wed, 22 Mar 2017 20:08:29 GMT', Server: gunicorn/19.7.1, Via: 1.1 vegur}
+    status: {code: 200, message: OK}
+    url: !!python/object/new:yarl.URL
+      state: !!python/tuple
+      - !!python/object/new:urllib.parse.SplitResult [https, httpbin.org, /get, ham=spam,
+        '']
+      - false
+version: 1

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ deps =
     boto: boto
     boto3: boto3
     aiohttp: aiohttp
+    aiohttp: pytest-asyncio
 
 [flake8]
 max_line_length = 110

--- a/vcr/_handle_coroutine.py
+++ b/vcr/_handle_coroutine.py
@@ -1,0 +1,7 @@
+import asyncio
+
+
+@asyncio.coroutine
+def handle_coroutine(vcr, fn):
+    with vcr as cassette:
+        return (yield from fn(cassette))  # noqa: E999


### PR DESCRIPTION
I'm currently using:

``` python
from vcr.cassette import CassetteContextDecorator

patchy.mc_patchface(CassetteContextDecorator._handle_coroutine, """\
    @@ -1,4 +1,4 @@
    -def _handle_coroutine(self, function, args, kwargs):
    +async def _handle_coroutine(self, function, args, kwargs):
         """Wraps a coroutine so that we're inside the cassette context for the
         duration of the coroutine.
         """
    @@ -6,11 +6,4 @@
             coroutine = self.__handle_function(cassette, function, args, kwargs)
             # We don't need to catch StopIteration. The caller (Tornado's
             # gen.coroutine, for example) will handle that.
    -        to_yield = next(coroutine)
    -        while True:
    -            try:
    -                to_send = yield to_yield
    -            except Exception:
    -                to_yield = coroutine.throw(*sys.exc_info())
    -            else:
    -                to_yield = coroutine.send(to_send)
    +        await coroutine
""")
```

to handle:

```python
@my_vcr.use_cassette(filter_headers=['authorization'])
@pytest.mark.asyncio
async def test_some_thing() -> None:
    res = await some_thing()
    assert res.to_dict() == {'text': 'a', 'score': 0.1, 'entities': []}
```

if I don't include the patch, I get:

```pytb
Traceback (most recent call last):
  File "/home/graingert/projects/x/datascience/.tox/py35/lib/python3.5/site-packages/pytest_asyncio/plugin.py", line 77, in pytest_pyfunc_call
    asyncio.async(pyfuncitem.obj(**testargs), loop=event_loop))
  File "/usr/lib/python3.5/asyncio/base_events.py", line 466, in run_until_complete
    return future.result()
  File "/usr/lib/python3.5/asyncio/futures.py", line 293, in result
    raise self._exception
  File "/usr/lib/python3.5/asyncio/tasks.py", line 239, in _step
    result = coro.send(None)
  File "/home/graingert/projects/x/datascience/.tox/py35/lib/python3.5/site-packages/vcr/cassette.py", line 113, in _handle_coroutine
    to_yield = next(coroutine)
TypeError: 'coroutine' object is not an iterator
```
