### PR TITLE
aiohttp multidict query parameters

### DIFF
--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -111,6 +111,19 @@ def test_params(tmpdir, scheme):
         assert cassette.play_count == 1
 
 
+def test_params_with_duplicate_keys(tmpdir, scheme):
+    url = scheme + '://httpbin.org/get'
+    # the param 'a' has multiple values: 1, 2, and 3
+    params = [('a', 1), ('b', False), ('a', '2'), ('a', '3')]
+    with vcr.use_cassette(str(tmpdir.join('get.yaml'))) as cassette:
+        _, response_json = get(url, as_text=False, params=params)
+
+    with vcr.use_cassette(str(tmpdir.join('get.yaml'))) as cassette:
+        _, cassette_response_json = get(url, as_text=False, params=params)
+        assert cassette_response_json == response_json
+        assert cassette.play_count == 1
+
+
 def test_params_same_url_distinct_params(tmpdir, scheme):
     url = scheme + '://httpbin.org/get'
     params = {'a': 1, 'b': False, 'c': 'c'}

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -35,8 +35,12 @@ def vcr_request(cassette, real_request):
         data = kwargs.get('data')
         params = kwargs.get('params')
         if params:
-            for k, v in params.items():
-                params[k] = str(v)
+            # aiohttp supports multidict (dict or list of 2-item tuples)
+            if isinstance(params, dict):
+                for k, v in params.items():
+                    params[k] = str(v)
+            else:
+                kwargs['params'] = params = [(k, str(v)) for k, v in params]
 
         request_url = URL(url).with_query(params)
         vcr_request = Request(method, str(request_url), data, headers)


### PR DESCRIPTION
aiohttp supports multidict for headers and query parameters, allowing the user
to specify either a dict or a list of 2-item tuples as input. For example:

```python
async with aiohttp.ClientSession() as s:
    params = [('a', 'alpha'), ('b', 'bravo'), ('a', 'Alpha')]
    async with s.get('http://127.0.0.1:8888', params=params) as r:
        buf = await r.text()
```

This patches vcrpy to handle this specific case instead of only dict-like
objects.