### PR TITLE
When filtering post data, handle ContentType with specified charset (ex: "application/json;UTF-8")

### DIFF
--- a/vcr/filters.py
+++ b/vcr/filters.py
@@ -84,7 +84,7 @@ def replace_post_data_parameters(request, replacements):
     """
     replacements = dict(replacements)
     if request.method == 'POST' and not isinstance(request.body, BytesIO):
-        if request.headers.get('Content-Type') == 'application/json':
+        if request.headers.get('Content-Type').startswith('application/json'):
             json_data = json.loads(request.body.decode('utf-8'))
             for k, rv in replacements.items():
                 if k in json_data:


### PR DESCRIPTION
Hello,

Regarding the website Amundi.com, I was unable to filter the POST data username & password.
The Content-Type set is "application/json;UTF-8", so strict comparison with "application/json" is not possible.

Thanks for this great python module!
