### PR TITLE
Add verbosity inside CannotOverwriteExistingCassetteException.

### DIFF
--- a/vcr/stubs/__init__.py
+++ b/vcr/stubs/__init__.py
@@ -228,7 +228,7 @@ class VCRConnection(object):
                     "No match for the request (%r) was found. "
                     "Can't overwrite existing cassette (%r) in "
                     "your current record mode (%r)."
-                    % (self._vcr_request, self.cassette._path,
+                    % (self._vcr_request._to_dict(), self.cassette._path,
                        self.cassette.record_mode)
                 )
 


### PR DESCRIPTION
When I started using vcrpy I found that it's really hard to understand
what is different between old and new request if they are different.
For example, in my case it was usage of uuid.uuid4() to generate
random names (which were different on each run inside body of
POST requests).

Unfortunately vcrpy is not reporting those differences in a meaningful
manner, especially when combined with py.test or other test framework.

I change message for exception to provide full request description to user.
It should help one to find differences between cassette content
and changed request.

Old exception message:

No match for the request (<Request (POST) http://example.com>) was found...

New exception message:

No match for the request ({'body': '{"auth": {"tenantName": "tenant",
"passwordCredentials": {"username": "username",...}',
'headers': {'Content-Length': ['107'], .... }, 'method': 'POST',
'uri': 'http://example.com}) was found....