### PR TITLE
Update usage.rst

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -57,7 +57,7 @@ once
    file.
 
 It is similar to the new\_episodes record mode, but will prevent new,
-unexpected requests from being made (i.e. because the request URI
+unexpected requests from being made (e.g. because the request URI
 changed).
 
 once is the default record mode, used when you do not set one.


### PR DESCRIPTION
"i.e." is misleading because it means "in other words". In the context of this paragraph, "i.e." implies that "unexpected requests" are those that have a different URI.
I think a URI change is just one example of what could constitute an "unexpected" request. vcr does request matching based on method, port, body, etc.
So, I think "e.g." which means "for example" is the right phrase in this context.