### PR TITLE
Fix of registering custom persister and test.

### DIFF
--- a/tests/integration/test_register_persister.py
+++ b/tests/integration/test_register_persister.py
@@ -10,10 +10,27 @@ import vcr
 from vcr.persisters.filesystem import FilesystemPersister
 
 
+class CustomFilesystemPersister(object):
+    """
+    like default FilesystemPersister but
+    adds .test extension to cassette file
+    """
+    @staticmethod
+    def load_cassette(cassette_path, serializer):
+        cassette_path += '.test'
+        return FilesystemPersister.load_cassette(cassette_path, serializer)
+
+    @staticmethod
+    def save_cassette(cassette_path, cassette_dict, serializer):
+        cassette_path += '.test'
+        FilesystemPersister.save_cassette(cassette_path, cassette_dict,
+                                          serializer)
+
+
 def test_save_cassette_with_custom_persister(tmpdir, httpbin):
     '''Ensure you can save a cassette using custom persister'''
     my_vcr = vcr.VCR()
-    my_vcr.register_persister(FilesystemPersister)
+    my_vcr.register_persister(CustomFilesystemPersister)
 
     # Check to make sure directory doesnt exist
     assert not os.path.exists(str(tmpdir.join('nonexistent')))
@@ -23,7 +40,7 @@ def test_save_cassette_with_custom_persister(tmpdir, httpbin):
         urlopen(httpbin.url).read()
 
     # Callback should have made the file and the directory
-    assert os.path.exists(str(tmpdir.join('nonexistent', 'cassette.yml')))
+    assert os.path.exists(str(tmpdir.join('nonexistent', 'cassette.yml.test')))
 
 
 def test_load_cassette_with_custom_persister(tmpdir, httpbin):
@@ -31,9 +48,9 @@ def test_load_cassette_with_custom_persister(tmpdir, httpbin):
     Ensure you can load a cassette using custom persister
     '''
     my_vcr = vcr.VCR()
-    my_vcr.register_persister(FilesystemPersister)
+    my_vcr.register_persister(CustomFilesystemPersister)
 
-    test_fixture = str(tmpdir.join('synopsis.json'))
+    test_fixture = str(tmpdir.join('synopsis.json.test'))
 
     with my_vcr.use_cassette(test_fixture, serializer='json'):
         response = urlopen(httpbin.url).read()

--- a/tests/integration/test_register_persister.py
+++ b/tests/integration/test_register_persister.py
@@ -11,8 +11,8 @@ from vcr.persisters.filesystem import FilesystemPersister
 
 
 class CustomFilesystemPersister(object):
-    '''Behaves just like DefaultFilePersister but adds .test extension to the
-       cassette file'''
+    '''Behaves just like default FilesystemPersister but adds .test extension
+       to the cassette file'''
     @staticmethod
     def load_cassette(cassette_path, serializer):
         cassette_path += '.test'
@@ -27,6 +27,7 @@ class CustomFilesystemPersister(object):
 
 def test_save_cassette_with_custom_persister(tmpdir, httpbin):
     '''Ensure you can save a cassette using custom persister'''
+    import ipdb; ipdb.set_trace()
     my_vcr = vcr.VCR()
     my_vcr.register_persister(CustomFilesystemPersister)
 
@@ -45,6 +46,7 @@ def test_load_cassette_with_custom_persister(tmpdir, httpbin):
     '''
     Ensure you can load a cassette using custom persister
     '''
+    import ipdb; ipdb.set_trace()
     my_vcr = vcr.VCR()
     my_vcr.register_persister(CustomFilesystemPersister)
 

--- a/tests/integration/test_register_persister.py
+++ b/tests/integration/test_register_persister.py
@@ -16,7 +16,7 @@ class CustomFilesystemPersister(object):
     @staticmethod
     def load_cassette(cassette_path, serializer):
         cassette_path += '.test'
-        return FilesystemPersister().load_cassette(cassette_path, serializer)
+        return FilesystemPersister.load_cassette(cassette_path, serializer)
 
     @staticmethod
     def save_cassette(cassette_path, cassette_dict, serializer):

--- a/tests/integration/test_register_persister.py
+++ b/tests/integration/test_register_persister.py
@@ -11,14 +11,12 @@ from vcr.persisters.filesystem import FilesystemPersister
 
 
 class CustomFilesystemPersister(object):
-    """
-    like default FilesystemPersister but
-    adds .test extension to cassette file
-    """
+    '''Behaves just like DefaultFilePersister but adds .test extension to the
+       cassette file'''
     @staticmethod
     def load_cassette(cassette_path, serializer):
         cassette_path += '.test'
-        return FilesystemPersister.load_cassette(cassette_path, serializer)
+        return FilesystemPersister().load_cassette(cassette_path, serializer)
 
     @staticmethod
     def save_cassette(cassette_path, cassette_dict, serializer):

--- a/tests/integration/test_register_persister.py
+++ b/tests/integration/test_register_persister.py
@@ -27,7 +27,6 @@ class CustomFilesystemPersister(object):
 
 def test_save_cassette_with_custom_persister(tmpdir, httpbin):
     '''Ensure you can save a cassette using custom persister'''
-    import ipdb; ipdb.set_trace()
     my_vcr = vcr.VCR()
     my_vcr.register_persister(CustomFilesystemPersister)
 
@@ -46,7 +45,6 @@ def test_load_cassette_with_custom_persister(tmpdir, httpbin):
     '''
     Ensure you can load a cassette using custom persister
     '''
-    import ipdb; ipdb.set_trace()
     my_vcr = vcr.VCR()
     my_vcr.register_persister(CustomFilesystemPersister)
 

--- a/vcr/config.py
+++ b/vcr/config.py
@@ -145,6 +145,7 @@ class VCR(object):
 
         merged_config = {
             'serializer': self._get_serializer(serializer_name),
+            'persister': self.persister,
             'match_on': self._get_matchers(
                 tuple(matcher_names) + tuple(additional_matchers)
             ),

--- a/vcr/persisters/filesystem.py
+++ b/vcr/persisters/filesystem.py
@@ -6,8 +6,8 @@ from ..serialize import serialize, deserialize
 
 class FilesystemPersister(object):
 
-    @classmethod
-    def load_cassette(cls, cassette_path, serializer):
+    @staticmethod
+    def load_cassette(cassette_path, serializer):
         try:
             with open(cassette_path) as f:
                 cassette_content = f.read()

--- a/vcr/persisters/filesystem.py
+++ b/vcr/persisters/filesystem.py
@@ -6,8 +6,8 @@ from ..serialize import serialize, deserialize
 
 class FilesystemPersister(object):
 
-    @staticmethod
-    def load_cassette(cassette_path, serializer):
+    @classmethod
+    def load_cassette(cls, cassette_path, serializer):
         try:
             with open(cassette_path) as f:
                 cassette_content = f.read()


### PR DESCRIPTION
Old test_register_persister.py used FilesystemPersister, which is used as default, so didn't catch the problem. Without added missing persister config to config.py the test fails, because it's using the default even if register_persister is called.

Fixes #334 