### PR TITLE
Reduce test matrix from 96 to 30 jobs?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,29 +7,14 @@ env:
     - secure: LBSEg/gMj4u4Hrpo3zs6Y/1mTpd2RtcN49mZIFgTdbJ9IhpiNPqcEt647Lz94F9Eses2x2WbNuKqZKZZReY7QLbEzU1m0nN5jlaKrjcG5NR5clNABfFFyhgc0jBikyS4abAG8jc2efeaTrFuQwdoF4sE8YiVrkiVj2X5Xoi6sBk=
   matrix:
     - TOX_SUFFIX="flakes"
-    - TOX_SUFFIX="requests22"
-    - TOX_SUFFIX="requests23"
-    - TOX_SUFFIX="requests24"
-    - TOX_SUFFIX="requests25"
-    - TOX_SUFFIX="requests26"
     - TOX_SUFFIX="requests27"
-    - TOX_SUFFIX="requests211"
-    - TOX_SUFFIX="requests213"
-    - TOX_SUFFIX="requests216"
-    - TOX_SUFFIX="requests218"
-    - TOX_SUFFIX="requests1"
     - TOX_SUFFIX="httplib2"
-    - TOX_SUFFIX="boto"
     - TOX_SUFFIX="boto3"
-    - TOX_SUFFIX="urllib319"
-    - TOX_SUFFIX="urllib3110"
     - TOX_SUFFIX="urllib3121"
-    - TOX_SUFFIX="tornado3"
     - TOX_SUFFIX="tornado4"
     - TOX_SUFFIX="aiohttp"
 matrix:
   allow_failures:
-    - env: TOX_SUFFIX="boto"
     - env: TOX_SUFFIX="boto3"
   exclude:
     # Only run flakes on a single Python 2.x and a single 3.x
@@ -40,17 +25,6 @@ matrix:
     - env: TOX_SUFFIX="flakes"
       python: pypy
     - env: TOX_SUFFIX="flakes"
-      python: "pypy3.5-5.9.0"
-    - env: TOX_SUFFIX="boto"
-      python: 3.6
-    # Requests 1.x only supports Python <= 3.3
-    - env: TOX_SUFFIX="requests1"
-      python: 3.4
-    - env: TOX_SUFFIX="requests1"
-      python: 3.5
-    - env: TOX_SUFFIX="requests1"
-      python: 3.6
-    - env: TOX_SUFFIX="requests1"
       python: "pypy3.5-5.9.0"
     - env: TOX_SUFFIX="aiohttp"
       python: 2.7

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,6 @@ VCR.py works great with the following HTTP clients:
 -  urllib3
 -  tornado
 -  urllib2
--  boto
 -  boto3
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py35,py36,pypy}-{flakes,requests218,requests216,requests213,requests211,requests27,requests26,requests25,requests24,requests23,requests22,requests1,httplib2,urllib319,urllib3110,urllib3121,tornado3,tornado4,boto,boto3,aiohttp}
+envlist = {py27,py35,py36,pypy}-{flakes,requests27,httplib2,urllib3121,tornado4,boto3,aiohttp}
 
 [testenv:flakes]
 skipsdist = True
@@ -18,28 +18,12 @@ deps =
     pytest
     pytest-httpbin
     PyYAML
-    requests1: requests==1.2.3
-    requests218: requests==2.18.4
-    requests216: requests==2.16.3
-    requests213: requests==2.13.0
-    requests211: requests==2.11.1
     requests27: requests==2.7.0
-    requests26: requests==2.6.0
-    requests25: requests==2.5.0
-    requests24: requests==2.4.0
-    requests23: requests==2.3.0
-    requests22: requests==2.2.1
     httplib2: httplib2
-    urllib319: urllib3==1.9.1
-    urllib3110: urllib3==1.10.2
     urllib3121: urllib3==1.21.1
-    {py27,py35,py36,pypy}-tornado3: tornado>=3,<4
     {py27,py35,py36,pypy}-tornado4: tornado>=4,<5
-    {py27,py35,py36,pypy}-tornado3: pytest-tornado
     {py27,py35,py36,pypy}-tornado4: pytest-tornado
-    {py27,py35,py36}-tornado3: pycurl
     {py27,py35,py36}-tornado4: pycurl
-    boto: boto
     boto3: boto3
     aiohttp: aiohttp
     aiohttp: pytest-asyncio


### PR DESCRIPTION
Opening this for discussion.

I'd like to suggest running 96 build jobs is a bit unweildy. It uses around 4.5 hours of CI time in total, about 1 hour from start to finish ([eg.](https://travis-ci.org/hugovk/vcrpy/builds/329772785)).

That's a long time to wait to see if a build passes, and holds up other builds.

It's testing 6 Python versions against 11 Requests versions, 3 urllib3 versions, 2 Tornado versions, 2 boto versions, plus some aiohttp and flake8 jobs.

It looks like new Requests versions were added to the matrix as they were released. I think it's good to take stock from time to time and re-evaluate what is actually important.

* Is it really necessary to test against all those old versions of Requests, urllib3, Tornado and boto? Requests 1.2.3 was released nearly five years ago in 2013, longer than the last CPython 2.6.

* More fundamentally (as touched upon briefly in https://github.com/kevin1024/vcrpy/pull/340#issuecomment-357776765), does VCR.py need to make promises to the community to support so old releases of dependencies, and so many versions of them, or is it acceptable to ask of them to have recent versions?

* Do each of those dependencies make promises to support those old versions?

Further, until recently many of the build jobs were failing, giving less confidence in the CI/tests as a whole.

Finally, https://docs.travis-ci.com/user/customizing-the-build/#Build-Matrix says:

> *All build matrixes are currently limited to a maximum of* **200 JOBS** *for both private and public repositories. If you are on an open-source plan, please remember that Travis CI provides this service free of charge to the community. So please only specify the matrix you actually need.*

I'd recommend only testing against a single, recent version of each dependency, 30 jobs ([eg.](https://travis-ci.org/hugovk/vcrpy/builds/329776537)):

| Build | Number of jobs | Total CI time | Start to finish time |
| ----- | -------------- | ------------- | -------------------- |
| Lots of versions | 96 | 4 hrs 21 min 55 sec | 57 min 30 sec |
| Single version   | 30 | 1 hr 14 min 53 sec  | 19 min 17 sec |


Of course, I don't know the full history, so perhaps an extra old version may be necessary, but 96 seems a bit much, especially the 11 versions of Requests.

Thank you!
