### PR TITLE
Convert extras_require conditional deps to PEP 508 form.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python
 
 import sys
-import logging
 
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
-import pkg_resources
 
 long_description = open('README.rst', 'r').read()
 
@@ -25,8 +23,8 @@ class PyTest(TestCommand):
 
 
 install_requires = [
-    'PyYAML', 
-    'wrapt', 
+    'PyYAML',
+    'wrapt',
     'six>=1.5',
     'contextlib2; python_version=="2.7"',
     'mock; python_version=="2.7"',

--- a/setup.py
+++ b/setup.py
@@ -24,29 +24,14 @@ class PyTest(TestCommand):
         sys.exit(errno)
 
 
-install_requires = ['PyYAML', 'wrapt', 'six>=1.5']
-
-
-extras_require = {
-    ':python_version in "2.7"': ['contextlib2', 'mock'],
-    ':python_version in "3.4, 3.5, 3.6"': ['yarl'],
-}
-
-
-try:
-    if 'bdist_wheel' not in sys.argv:
-        for key, value in extras_require.items():
-            if key.startswith(':') and pkg_resources.evaluate_marker(key[1:]):
-                install_requires.extend(value)
-except Exception:
-    logging.getLogger(__name__).exception(
-        'Something went wrong calculating platform specific dependencies, so '
-        "you're getting them all!"
-    )
-    for key, value in extras_require.items():
-        if key.startswith(':'):
-            install_requires.extend(value)
-
+install_requires = [
+    'PyYAML', 
+    'wrapt', 
+    'six>=1.5',
+    'contextlib2; python_version=="2.7"',
+    'mock; python_version=="2.7"',
+    'yarl; python_version>="3.4"',
+]
 
 excluded_packages = ["tests*"]
 if sys.version_info[0] == 2:
@@ -66,7 +51,6 @@ setup(
     packages=find_packages(exclude=excluded_packages),
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     install_requires=install_requires,
-    extras_require=extras_require,
     license='MIT',
     tests_require=['pytest', 'mock', 'pytest-httpbin'],
     classifiers=[


### PR DESCRIPTION
This replaces `extras_require` with the [PEP 508 spec](https://www.python.org/dev/peps/pep-0508/) for specifying conditional dependencies.

I was motivated to do this while trying to use pipenv and vcrpy with a Python 2/3 project, and found pipenv trying to install yarl's multidict dependency on Python 2. This happened even though pipenv noted that yarl was being skipped for its Python-3-only restriction specified by vcrpy. I'm hoping this change will fix the problem.

See also: pyca/cryptography#4090.