### PR TITLE
Make the build reproducible

### DIFF
--- a/vcr/cassette.py
+++ b/vcr/cassette.py
@@ -175,13 +175,13 @@ class Cassette(object):
     def use(cls, **kwargs):
         return CassetteContextDecorator.from_args(cls, **kwargs)
 
-    def __init__(self, path, serializer=yamlserializer, persister=FilesystemPersister, record_mode='once',
+    def __init__(self, path, serializer=None, persister=None, record_mode='once',
                  match_on=(uri, method), before_record_request=None,
                  before_record_response=None, custom_patches=(),
                  inject=False):
-        self._persister = persister
+        self._persister = persister or FilesystemPersister
         self._path = path
-        self._serializer = serializer
+        self._serializer = serializer or yamlserializer
         self._match_on = match_on
         self._before_record_request = before_record_request or (lambda x: x)
         self._before_record_response = before_record_response or (lambda x: x)


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that vcrpy could not be built reproducibly.

This is due to the documentation including the absolute build path
via Python default arguments.

This was originally filed in Debian as #895269 [1].

 [0] https://reproducible-builds.org/
 [1] https://bugs.debian.org/895269

Signed-off-by: Chris Lamb <lamby@debian.org>