### PR TITLE
Fix broken tests + build quicker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,29 +7,14 @@ env:
     - secure: LBSEg/gMj4u4Hrpo3zs6Y/1mTpd2RtcN49mZIFgTdbJ9IhpiNPqcEt647Lz94F9Eses2x2WbNuKqZKZZReY7QLbEzU1m0nN5jlaKrjcG5NR5clNABfFFyhgc0jBikyS4abAG8jc2efeaTrFuQwdoF4sE8YiVrkiVj2X5Xoi6sBk=
   matrix:
     - TOX_SUFFIX="flakes"
-    - TOX_SUFFIX="requests22"
-    - TOX_SUFFIX="requests23"
-    - TOX_SUFFIX="requests24"
-    - TOX_SUFFIX="requests25"
-    - TOX_SUFFIX="requests26"
     - TOX_SUFFIX="requests27"
-    - TOX_SUFFIX="requests211"
-    - TOX_SUFFIX="requests213"
-    - TOX_SUFFIX="requests216"
-    - TOX_SUFFIX="requests218"
-    - TOX_SUFFIX="requests1"
     - TOX_SUFFIX="httplib2"
-    - TOX_SUFFIX="boto"
     - TOX_SUFFIX="boto3"
-    - TOX_SUFFIX="urllib319"
-    - TOX_SUFFIX="urllib3110"
     - TOX_SUFFIX="urllib3121"
-    - TOX_SUFFIX="tornado3"
     - TOX_SUFFIX="tornado4"
     - TOX_SUFFIX="aiohttp"
 matrix:
   allow_failures:
-    - env: TOX_SUFFIX="boto"
     - env: TOX_SUFFIX="boto3"
   exclude:
     # Only run flakes on a single Python 2.x and a single 3.x
@@ -40,17 +25,6 @@ matrix:
     - env: TOX_SUFFIX="flakes"
       python: pypy
     - env: TOX_SUFFIX="flakes"
-      python: "pypy3.5-5.9.0"
-    - env: TOX_SUFFIX="boto"
-      python: 3.6
-    # Requests 1.x only supports Python <= 3.3
-    - env: TOX_SUFFIX="requests1"
-      python: 3.4
-    - env: TOX_SUFFIX="requests1"
-      python: 3.5
-    - env: TOX_SUFFIX="requests1"
-      python: 3.6
-    - env: TOX_SUFFIX="requests1"
       python: "pypy3.5-5.9.0"
     - env: TOX_SUFFIX="aiohttp"
       python: 2.7

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,6 @@ VCR.py works great with the following HTTP clients:
 -  urllib3
 -  tornado
 -  urllib2
--  boto
 -  boto3
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps = flake8
 commands =
     ./runtests.sh {posargs}
 deps =
-    Flask
+    Flask<1
     mock
     pytest
     pytest-httpbin

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py35,py36,pypy}-{flakes,requests218,requests216,requests213,requests211,requests27,requests26,requests25,requests24,requests23,requests22,requests1,httplib2,urllib319,urllib3110,urllib3121,tornado3,tornado4,boto,boto3,aiohttp}
+envlist = {py27,py35,py36,pypy}-{flakes,requests27,httplib2,urllib3121,tornado4,boto3,aiohttp}
 
 [testenv:flakes]
 skipsdist = True
@@ -18,28 +18,12 @@ deps =
     pytest
     pytest-httpbin
     PyYAML
-    requests1: requests==1.2.3
-    requests218: requests==2.18.4
-    requests216: requests==2.16.3
-    requests213: requests==2.13.0
-    requests211: requests==2.11.1
     requests27: requests==2.7.0
-    requests26: requests==2.6.0
-    requests25: requests==2.5.0
-    requests24: requests==2.4.0
-    requests23: requests==2.3.0
-    requests22: requests==2.2.1
     httplib2: httplib2
-    urllib319: urllib3==1.9.1
-    urllib3110: urllib3==1.10.2
     urllib3121: urllib3==1.21.1
-    {py27,py35,py36,pypy}-tornado3: tornado>=3,<4
     {py27,py35,py36,pypy}-tornado4: tornado>=4,<5
-    {py27,py35,py36,pypy}-tornado3: pytest-tornado
     {py27,py35,py36,pypy}-tornado4: pytest-tornado
-    {py27,py35,py36}-tornado3: pycurl
     {py27,py35,py36}-tornado4: pycurl
-    boto: boto
     boto3: boto3
     aiohttp: aiohttp
     aiohttp: pytest-asyncio

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
     {py27,py35,py36,pypy}-tornado4: pytest-tornado
     {py27,py35,py36}-tornado4: pycurl
     boto3: boto3
-    aiohttp: aiohttp
+    aiohttp: aiohttp<3
     aiohttp: pytest-asyncio
 
 [flake8]


### PR DESCRIPTION
Many CI builds are currently broken. After some investigation I found the major causes for it are:

- Old python and library versions. Fixed by removing tests from tox/travis (thanks to hugovk on #344)
- Some new releases of test-only libs such as Flask>=1.0 and aiohttp >= 3. Fixed by pinning versions on tox while the support is implemented. 

This PR fixes that :soccer: :top: