### PR TITLE
fixes before_record_response mutates response

### DIFF
--- a/vcr/cassette.py
+++ b/vcr/cassette.py
@@ -1,4 +1,5 @@
 import collections
+import copy
 import sys
 import inspect
 import logging
@@ -222,6 +223,9 @@ class Cassette(object):
         request = self._before_record_request(request)
         if not request:
             return
+        # Deepcopy is here because mutation of `response` will corrupt the
+        # real response.
+        response = copy.deepcopy(response)
         response = self._before_record_response(response)
         if response is None:
             return


### PR DESCRIPTION
When no cassette exists, it's expected that the response returned should be
the original, unchanged response. The response recorded in the cassette should be
that which is returned by the before_record_response callback.

But on subsequent requests/responses (when a cassette exists), the responses
returned should be exactly what is in the cassette.

resolves #355