### PR TITLE
Preserve existing query parameters in request url

### DIFF
--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -57,7 +57,6 @@ def vcr_request(cassette, real_request):
             for k, v in params.items():
                 query_params[k] = str(v)
         request_url = URL(url).with_query(query_params)
-        
         vcr_request = Request(method, str(request_url), data, headers)
 
         if cassette.can_play_response_for(vcr_request):

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -52,7 +52,7 @@ def vcr_request(cassette, real_request):
         headers = self._prepare_headers(headers)
         data = kwargs.get('data')
         params = kwargs.get('params')
-        query_params = URL(url).query
+        query_params = URL(url).query.copy()
         if params:
             for k, v in params.items():
                 query_params[k] = str(v)

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -52,11 +52,12 @@ def vcr_request(cassette, real_request):
         headers = self._prepare_headers(headers)
         data = kwargs.get('data')
         params = kwargs.get('params')
-        query_params = URL(url).query.copy()
         if params:
             for k, v in params.items():
-                query_params[k] = str(v)
-        request_url = URL(url).with_query(query_params)
+                params[k] = str(v)
+            request_url = URL(url).with_query(params)
+        else:
+            request_url = URL(url)
         vcr_request = Request(method, str(request_url), data, headers)
 
         if cassette.can_play_response_for(vcr_request):

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -52,11 +52,12 @@ def vcr_request(cassette, real_request):
         headers = self._prepare_headers(headers)
         data = kwargs.get('data')
         params = kwargs.get('params')
+        query_params = URL(url).query
         if params:
             for k, v in params.items():
-                params[k] = str(v)
-
-        request_url = URL(url).with_query(params)
+                query_params[k] = str(v)
+        request_url = URL(url).with_query(query_params)
+        
         vcr_request = Request(method, str(request_url), data, headers)
 
         if cassette.can_play_response_for(vcr_request):


### PR DESCRIPTION
Currently when running VCRpy over a project using aiohttp, the cassettes lose the query parameters that existed in the urls.  

E.g. A request for `https://www.kogan.com/au/?name=hello` is saved in the cassette as `https://www.kogan.com/au/`.  This causes problems when you are testing multiple urls that have different query parameters on the same host.

This crude change preserves the original query parameters in the request_url so that the corresponding cassettes don't lose their query strings.