### PR TITLE
Update docs' lists of supported HTTP clients

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,19 +41,6 @@ VCR.py will detect the absence of a cassette file and once again record
 all HTTP interactions, which will update them to correspond to the new
 API.
 
-Support
--------
-
-VCR.py works great with the following HTTP clients:
-
--  requests
--  aiohttp
--  urllib3
--  tornado
--  urllib2
--  boto3
-
-
 License
 =======
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,7 +20,7 @@ The following HTTP libraries are supported:
 -  ``http.client``
 -  ``httplib2``
 -  ``requests`` (both 1.x and 2.x versions)
--  ``tornado``
+-  ``tornado.httpclient``
 -  ``urllib2``
 -  ``urllib3``
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,15 +12,17 @@ Compatibility
 VCR.py supports Python 2.7 and 3.4+, and
 `pypy <http://pypy.org>`__.
 
-The following http libraries are supported:
+The following HTTP libraries are supported:
 
--  urllib2
--  urllib3
--  http.client (python3)
--  requests (both 1.x and 2.x versions)
--  httplib2
--  boto
--  Tornado's AsyncHTTPClient
+-  ``aiohttp``
+-  ``boto``
+-  ``boto3``
+-  ``http.client``
+-  ``httplib2``
+-  ``requests`` (both 1.x and 2.x versions)
+-  ``tornado``
+-  ``urllib2``
+-  ``urllib3``
 
 Speed
 -----


### PR DESCRIPTION
I noticed these were out of sync, especially weirdly one mentioning boto and the other mentioning boto3. I figure the list in the README is redundant when the Installation docs section lists the supported libraries, so I've removed it. I also:

* alphabetically sorted the list
* Highlighted the library names as code
* Added both `boto` and `boto3` to the list since there is support for both
* Removed the comment about Tornado's AsyncHTTPClient since that's an implementation detail plus the patch happens on a couple different classes
* Removed the note about `http.client` being part of Python 3, because everyone is Python 3 these days anyway :)