### PR TITLE
Fix PyPI badge URLs in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,9 +61,9 @@ This library uses the MIT license. See `LICENSE.txt <LICENSE.txt>`__ for
 more details
 
 .. |PyPI| image:: https://img.shields.io/pypi/v/vcrpy.svg
-   :target: https://pypi.python.org/pypi/vcrpy-unittest
-.. |Python versions| image:: https://img.shields.io/pypi/pyversions/vcrpy-unittest.svg
-   :target: https://pypi.python.org/pypi/vcrpy-unittest
+   :target: https://pypi.python.org/pypi/vcrpy
+.. |Python versions| image:: https://img.shields.io/pypi/pyversions/vcrpy.svg
+   :target: https://pypi.python.org/pypi/vcrpy
 .. |Build Status| image:: https://secure.travis-ci.org/kevin1024/vcrpy.png?branch=master
    :target: http://travis-ci.org/kevin1024/vcrpy
 .. |Waffle Ready| image:: https://badge.waffle.io/kevin1024/vcrpy.png?label=ready&title=waffle

--- a/README.rst
+++ b/README.rst
@@ -64,9 +64,9 @@ more details
    :target: https://pypi.python.org/pypi/vcrpy
 .. |Python versions| image:: https://img.shields.io/pypi/pyversions/vcrpy.svg
    :target: https://pypi.python.org/pypi/vcrpy
-.. |Build Status| image:: https://secure.travis-ci.org/kevin1024/vcrpy.png?branch=master
+.. |Build Status| image:: https://secure.travis-ci.org/kevin1024/vcrpy.svg?branch=master
    :target: http://travis-ci.org/kevin1024/vcrpy
-.. |Waffle Ready| image:: https://badge.waffle.io/kevin1024/vcrpy.png?label=ready&title=waffle
+.. |Waffle Ready| image:: https://badge.waffle.io/kevin1024/vcrpy.svg?label=ready&title=waffle
    :target: https://waffle.io/kevin1024/vcrpy
 .. |Gitter| image:: https://badges.gitter.im/Join%20Chat.svg
    :alt: Join the chat at https://gitter.im/kevin1024/vcrpy


### PR DESCRIPTION
Changed `vcrpy-unittest` to `vcrpy` in PyPI URLs. I assume linking to [`vcrpy-unittest`](https://pypi.org/project/vcrpy-unittest/) was not intentional?