### PR TITLE
 Fix matching on 'body' failing when Unicode symbols are present

### DIFF
--- a/tests/integration/test_requests.py
+++ b/tests/integration/test_requests.py
@@ -254,7 +254,7 @@ def test_nested_cassettes_with_session_created_before_nesting(httpbin_both, tmpd
 def test_post_file(tmpdir, httpbin_both):
     '''Ensure that we handle posting a file.'''
     url = httpbin_both + '/post'
-    with vcr.use_cassette(str(tmpdir.join('post_file.yaml'))) as cass, open('tox.ini') as f:
+    with vcr.use_cassette(str(tmpdir.join('post_file.yaml'))) as cass, open('tox.ini', 'rb') as f:
         original_response = requests.post(url, f).content
 
     # This also tests that we do the right thing with matching the body when they are files.

--- a/tests/integration/test_requests.py
+++ b/tests/integration/test_requests.py
@@ -282,3 +282,17 @@ def test_filter_post_params(tmpdir, httpbin_both):
         requests.post(url, data={'key': 'value'})
     with vcr.use_cassette(cass_loc, filter_post_data_parameters=['key']) as cass:
         assert b'key=value' not in cass.requests[0].body
+
+
+def test_post_unicode_match_on_body(tmpdir, httpbin_both):
+    '''Ensure that matching on POST body that contains Unicode characters works.'''
+    data = {'key1': 'value1', '●‿●': '٩(●̮̮̃•̃)۶'}
+    url = httpbin_both + '/post'
+
+    with vcr.use_cassette(str(tmpdir.join('requests.yaml')), additional_matchers=('body',)):
+        req1 = requests.post(url, data).content
+
+    with vcr.use_cassette(str(tmpdir.join('requests.yaml')), additional_matchers=('body',)):
+        req2 = requests.post(url, data).content
+
+    assert req1 == req2

--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -5,7 +5,7 @@ from vcr.request import Request, HeadersDict
 
 def test_str():
     req = Request('GET', 'http://www.google.com/', '', {})
-    str(req) == '<Request (GET) http://www.google.com/>'
+    assert str(req) == '<Request (GET) http://www.google.com/>'
 
 
 def test_headers():

--- a/tests/unit/test_vcr.py
+++ b/tests/unit/test_vcr.py
@@ -147,7 +147,7 @@ def test_vcr_path_transformer():
         # and it should still work with cassette_library_dir
         vcr = VCR(cassette_library_dir='/foo')
         with vcr.use_cassette('test') as cassette:
-            assert cassette._path == '/foo/test'
+            assert os.path.abspath(cassette._path) == os.path.abspath('/foo/test')
 
 
 @pytest.fixture

--- a/vcr/matchers.py
+++ b/vcr/matchers.py
@@ -56,9 +56,12 @@ def _transform_json(body):
 _xml_header_checker = _header_checker('text/xml')
 _xmlrpc_header_checker = _header_checker('xmlrpc', header='User-Agent')
 _checker_transformer_pairs = (
-    (_header_checker('application/x-www-form-urlencoded'), urllib.parse.parse_qs),
-    (_header_checker('application/json'), _transform_json),
-    (lambda request: _xml_header_checker(request) and _xmlrpc_header_checker(request), xmlrpc_client.loads),
+    (_header_checker('application/x-www-form-urlencoded'),
+        lambda body: urllib.parse.parse_qs(body.decode('ascii'))),
+    (_header_checker('application/json'),
+        _transform_json),
+    (lambda request: _xml_header_checker(request) and _xmlrpc_header_checker(request),
+        xmlrpc_client.loads),
 )
 
 


### PR DESCRIPTION
Matching on bodies uses `urllib.parse.parse_qs()`, which for some reason fails to handle UTF-8+URLEncoded POST bodies when the input is `bytes` rather than `str`, causing matching to fail.

I fixed this by always doing `decode('ascii')` on URLEncoded POST bodies first.

I also fixed some unrelated unit tests that failed on Windows.

This is the output the added `test_post_unicode_match_on_body` unit test would currently produce without the included fix:
```python
    def test_post_unicode_match_on_body(tmpdir, httpbin_both):
        '''Ensure that matching on POST body that contains Unicode characters works.'''
        data = {'key1': 'value1', '●‿●': '٩(●̮̮̃•̃)۶'}
        url = httpbin_both + '/post'
    
        with vcr.use_cassette(str(tmpdir.join('requests.yaml')), additional_matchers=('body',)):
            req1 = requests.post(url, data).content
    
        with vcr.use_cassette(str(tmpdir.join('requests.yaml')), additional_matchers=('body',)):
>           req2 = requests.post(url, data).content

tests/integration/test_requests.py:296: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
site-packages/requests/api.py:112: in post
    return request('post', url, data=data, json=json, **kwargs)
site-packages/requests/api.py:58: in request
    return session.request(method=method, url=url, **kwargs)
site-packages/requests/sessions.py:512: in request
    resp = self.send(prep, **send_kwargs)
site-packages/requests/sessions.py:622: in send
    r = adapter.send(request, **kwargs)
site-packages/requests/adapters.py:445: in send
    timeout=timeout
site-packages/urllib3/connectionpool.py:600: in urlopen
    chunked=chunked)
site-packages/urllib3/connectionpool.py:377: in _make_request
    httplib_response = conn.getresponse(buffering=True)
vcr/stubs/__init__.py:215: in getresponse
    if self.cassette.can_play_response_for(self._vcr_request):
vcr/cassette.py:250: in can_play_response_for
    return request and request in self and \
vcr/cassette.py:321: in __contains__
    for index, response in self._responses(request):
vcr/cassette.py:245: in _responses
    if requests_match(request, stored_request, self._match_on):
vcr/matchers.py:99: in requests_match
    matches = [(m(r1, r2), m) for m in matchers]
vcr/matchers.py:99: in <listcomp>
    matches = [(m(r1, r2), m) for m in matchers]
vcr/matchers.py:82: in body
    return transformer(read_body(r1)) == transformer(read_body(r2))
vcr/matchers.py:59: in <lambda>
    (_header_checker('application/x-www-form-urlencoded'), lambda body: urllib.parse.parse_qs(body)),
urllib/parse.py:652: in parse_qs
    encoding=encoding, errors=errors)
urllib/parse.py:702: in parse_qsl
    name = _coerce_result(name)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

obj = '●‿●', encoding = 'ascii', errors = 'strict'

    def _encode_result(obj, encoding=_implicit_encoding,
                            errors=_implicit_errors):
>       return obj.encode(encoding, errors)
E       UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-2: ordinal not in range(128)

urllib/parse.py:103: UnicodeEncodeError
```