### PR TITLE
ClientResponse.release isn't a coroutine

### DIFF
--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -34,7 +34,7 @@ class MockClientResponse(ClientResponse):
     async def read(self):
         return self._body
 
-    async def release(self):
+    def release(self):
         pass
 
 


### PR DESCRIPTION
Therefore it should not be one in the MockClientResponse class.

https://github.com/aio-libs/aiohttp/blob/d0af887e3121d677b32339adff6540b6de01d167/aiohttp/client_reqrep.py#L832