### PR TITLE
Uses yield from in _handle_generator instead of a lookalike that doesn't work anymore

### DIFF
--- a/vcr/cassette_nyf.py
+++ b/vcr/cassette_nyf.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+import sys
+
+def _loc_handle_generator(self, fn):
+    """Wraps a generator so that we're inside the cassette context for the
+    duration of the generator.
+    """
+    with self as cassette:
+        coroutine = fn(cassette)
+
+        to_yield = next(coroutine)
+        while True:
+            try:
+                to_send = yield to_yield
+            except Exception:
+                to_yield = coroutine.throw(*sys.exc_info())
+            else:
+                try:
+                   to_yield = coroutine.send(to_send)
+                except StopIteration:
+                    break

--- a/vcr/cassette_yf.py
+++ b/vcr/cassette_yf.py
@@ -1,0 +1,7 @@
+def _loc_handle_generator(self, fn):
+    """Wraps a generator so that we're inside the cassette context for the
+    duration of the generator.
+    """
+    with self as cassette:
+        coroutine = fn(cassette)
+        yield from coroutine


### PR DESCRIPTION
Dear @kevin1024,

PEP479 is active in python3.7 now, and this breaks _handle_generator. I've filed an issue to report this, and worked on finding a fix.

Essentially, this fix consists in using yield from coroutine in _handle_generator, but as this pattern is not python2.7 compliant, I designed a full patch.

This PR would close issue #396 