### PR TITLE
Handle PEP 479 with backward compat for python2.7

### DIFF
--- a/vcr/cassette.py
+++ b/vcr/cassette.py
@@ -132,7 +132,10 @@ class CassetteContextDecorator(object):
                 try:
                     to_send = yield to_yield
                 except Exception:
-                    to_yield = coroutine.throw(*sys.exc_info())
+                    try:
+                        to_yield = coroutine.throw(*sys.exc_info())
+                    except StopIteration:
+                        break
                 else:
                     try:
                         to_yield = coroutine.send(to_send)


### PR DESCRIPTION
PEP479 renders the _handle_generator function of CassetteContextDecorator
object erroneous in python3.7. Yet, we can't rely properly on yield from
as python2.7 compat is still mandatory. Try to find a good balance
between these two facts

@graingert is it better for you?

This would close #396 