### PR TITLE
FIX behaviour MockClientResponse.json() if body is empty

### DIFF
--- a/tests/integration/aiohttp_utils.py
+++ b/tests/integration/aiohttp_utils.py
@@ -30,6 +30,14 @@ def aiohttp_app():
     async def hello(request):
         return aiohttp.web.Response(text='hello')
 
+    async def json(request):
+        return aiohttp.web.json_response({})
+
+    async def json_empty_body(request):
+        return aiohttp.web.json_response()
+
     app = aiohttp.web.Application()
     app.router.add_get('/', hello)
+    app.router.add_get('/json', json)
+    app.router.add_get('/json/empty', json_empty_body)
     return app

--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -191,3 +191,26 @@ def test_aiohttp_test_client(aiohttp_client, tmpdir):
     response_text = loop.run_until_complete(response.text())
     assert response_text == 'hello'
     assert cassette.play_count == 1
+
+
+def test_aiohttp_test_client_json(aiohttp_client, tmpdir):
+    loop = asyncio.get_event_loop()
+    app = aiohttp_app()
+    url = '/json/empty'
+    client = loop.run_until_complete(aiohttp_client(app))
+
+    with vcr.use_cassette(str(tmpdir.join('get.yaml'))):
+        response = loop.run_until_complete(client.get(url))
+
+    assert response.status == 200
+    response_json = loop.run_until_complete(response.json())
+    assert response_json is None
+
+    with vcr.use_cassette(str(tmpdir.join('get.yaml'))) as cassette:
+        response = loop.run_until_complete(client.get(url))
+
+    request = cassette.requests[0]
+    assert request.url == str(client.make_url(url))
+    response_json = loop.run_until_complete(response.json())
+    assert response_json is None
+    assert cassette.play_count == 1

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -30,7 +30,11 @@ class MockClientResponse(ClientResponse):
         )
 
     async def json(self, *, encoding='utf-8', loads=json.loads, **kwargs):  # NOQA: E999
-        return loads(self._body.decode(encoding))
+        stripped = self._body.strip()
+        if not stripped:
+            return None
+
+        return loads(stripped.decode(encoding))
 
     async def text(self, encoding='utf-8', errors='strict'):
         return self._body.decode(encoding, errors=errors)


### PR DESCRIPTION
When I have a mock like this:

  

```
response:
    body: {string: ''}
```

I have next error:
```
venv/lib/python3.6/site-packages/vcr/stubs/aiohttp_stubs/__init__.py:29: in json
    return loads(self._body.decode(encoding))
/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/__init__.py:354: in loads
    return _default_decoder.decode(s)
/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/decoder.py:339: in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/decoder.py:357: in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
E   json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```
Because it tried to decode empty string.

But in the same time aiohttp behave differently.
https://github.com/aio-libs/aiohttp/blob/master/aiohttp/client_reqrep.py#L1002

This should help.
