### PR TITLE
Record `json` kwarg in aiohttp request

### DIFF
--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -47,13 +47,17 @@ def test_status(tmpdir, scheme):
         assert cassette.play_count == 1
 
 
-def test_headers(tmpdir, scheme):
+@pytest.mark.parametrize("auth", [None, aiohttp.BasicAuth("vcrpy", "test")])
+def test_headers(tmpdir, scheme, auth):
     url = scheme + '://httpbin.org'
     with vcr.use_cassette(str(tmpdir.join('headers.yaml'))):
-        response, _ = get(url)
+        response, _ = get(url, auth=auth)
 
     with vcr.use_cassette(str(tmpdir.join('headers.yaml'))) as cassette:
-        cassette_response, _ = get(url)
+        if auth is not None:
+            request = cassette.requests[0]
+            assert "AUTHORIZATION" in request.headers
+        cassette_response, _ = get(url, auth=auth)
         assert cassette_response.headers == response.headers
         assert cassette.play_count == 1
 

--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -105,14 +105,17 @@ def test_stream(tmpdir, scheme):
         assert cassette.play_count == 1
 
 
-def test_post(tmpdir, scheme):
+@pytest.mark.parametrize('body', ['data', 'json'])
+def test_post(tmpdir, scheme, body):
     data = {'key1': 'value1', 'key2': 'value2'}
     url = scheme + '://httpbin.org/post'
     with vcr.use_cassette(str(tmpdir.join('post.yaml'))):
-        _, response_json = post(url, data=data)
+        _, response_json = post(url, **{body: data})
 
     with vcr.use_cassette(str(tmpdir.join('post.yaml'))) as cassette:
-        _, cassette_response_json = post(url, data=data)
+        request = cassette.requests[0]
+        assert request.body == data
+        _, cassette_response_json = post(url, **{body: data})
         assert cassette_response_json == response_json
         assert cassette.play_count == 1
 

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -3,12 +3,15 @@ from __future__ import absolute_import
 
 import asyncio
 import functools
+import logging
 import json
 
 from aiohttp import ClientResponse, streams
 from yarl import URL
 
 from vcr.request import Request
+
+log = logging.getLogger(__name__)
 
 
 class MockStream(asyncio.StreamReader, streams.AsyncStreamReaderMixin):
@@ -90,6 +93,10 @@ def vcr_request(cassette, real_request):
             response._body = msg.encode()
             response.close()
             return response
+
+        log.info(
+            "{} not in cassette, sending to real server".format(vcr_request)
+        )
 
         response = await real_request(self, method, url, **kwargs)  # NOQA: E999
 

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -58,7 +58,7 @@ def vcr_request(cassette, real_request):
     async def new_request(self, method, url, **kwargs):
         headers = kwargs.get('headers')
         headers = self._prepare_headers(headers)
-        data = kwargs.get('data')
+        data = kwargs.get('data', kwargs.get('json'))
         params = kwargs.get('params')
 
         request_url = URL(url)

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -60,9 +60,13 @@ def vcr_request(cassette, real_request):
     @functools.wraps(real_request)
     async def new_request(self, method, url, **kwargs):
         headers = kwargs.get('headers')
+        auth = kwargs.get('auth')
         headers = self._prepare_headers(headers)
         data = kwargs.get('data', kwargs.get('json'))
         params = kwargs.get('params')
+
+        if auth is not None:
+            headers['AUTHORIZATION'] = auth.encode()
 
         request_url = URL(url)
         if params:
@@ -94,9 +98,7 @@ def vcr_request(cassette, real_request):
             response.close()
             return response
 
-        log.info(
-            "{} not in cassette, sending to real server".format(vcr_request)
-        )
+        log.info("{} not in cassette, sending to real server", vcr_request)
 
         response = await real_request(self, method, url, **kwargs)  # NOQA: E999
 


### PR DESCRIPTION
Aiohttp supports `data` and `json` parameters to make a request.
Aiohttp enforces that only one is used make a request.

The issue is mentioned in comments of #405 .