### PR TITLE
Add a `rewind` method to reset a cassette.

### DIFF
--- a/tests/unit/test_cassettes.py
+++ b/tests/unit/test_cassettes.py
@@ -133,6 +133,17 @@ def test_cassette_all_played():
     assert a.all_played
 
 
+@mock.patch('vcr.cassette.requests_match', _mock_requests_match)
+def test_cassette_rewound():
+    a = Cassette('test')
+    a.append('foo', 'bar')
+    a.play_response('foo')
+    assert a.all_played
+
+    a.rewind()
+    assert not a.all_played
+
+
 def test_before_record_response():
     before_record_response = mock.Mock(return_value='mutated')
     cassette = Cassette('test', before_record_response=before_record_response)

--- a/vcr/cassette.py
+++ b/vcr/cassette.py
@@ -287,6 +287,9 @@ class Cassette(object):
             % (self._path, request)
         )
 
+    def rewind(self):
+        self.play_counts = collections.Counter()
+
     def _as_dict(self):
         return {"requests": self.requests, "responses": self.responses}
 


### PR DESCRIPTION
Hi!

First, thank you for building/maintaining vcrpy — it's a very useful library! 

I'm currently writing a unit test that has to use the same cassette twice, but it turns out that there isn't a function to "rewind" the cassette. It looks like other people are interested in this feature (#357) so I thought I'd send a quick PR to add it.

I've also written a small unit test to exercise it. Please let me know if you'd like me to expand on it.

Thank you!