### PR TITLE
KeyError when replaying proxy tunnel captured sessions (broken in #389, v2.0.0)

### DIFF
--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -3,9 +3,13 @@ import pytest
 from vcr.request import Request, HeadersDict
 
 
-def test_str():
-    req = Request('GET', 'http://www.google.com/', '', {})
-    str(req) == '<Request (GET) http://www.google.com/>'
+@pytest.mark.parametrize("method, uri, expected_str", [
+    ('GET', 'http://www.google.com/', '<Request (GET) http://www.google.com/>'),
+    ('OPTIONS', '*', '<Request (OPTIONS) *>'),
+    ('CONNECT', 'host.some.where:1234', '<Request (CONNECT) host.some.where:1234>')
+])
+def test_str(method, uri, expected_str):
+    assert str(Request(method, uri, '', {})) == expected_str
 
 
 def test_headers():
@@ -29,18 +33,21 @@ def test_add_header_deprecated():
     ('https://go.com/', 443),
     ('https://go.com:443/', 443),
     ('https://go.com:3000/', 3000),
+    ('*', None)
 ])
 def test_port(uri, expected_port):
     req = Request('GET', uri, '', {})
     assert req.port == expected_port
 
 
-def test_uri():
-    req = Request('GET', 'http://go.com/', '', {})
-    assert req.uri == 'http://go.com/'
-
-    req = Request('GET', 'http://go.com:80/', '', {})
-    assert req.uri == 'http://go.com:80/'
+@pytest.mark.parametrize("method, uri", [
+    ('GET', 'http://go.com/'),
+    ('GET', 'http://go.com:80/'),
+    ('CONNECT', 'localhost:1234'),
+    ('OPTIONS', '*')
+])
+def test_uri(method, uri):
+    assert Request(method, uri, '', {}).uri == uri
 
 
 def test_HeadersDict():

--- a/vcr/request.py
+++ b/vcr/request.py
@@ -58,7 +58,10 @@ class Request(object):
         parse_uri = urlparse(self.uri)
         port = parse_uri.port
         if port is None:
-            port = {'https': 443, 'http': 80}[parse_uri.scheme]
+            try:
+                port = {'https': 443, 'http': 80}[parse_uri.scheme]
+            except KeyError:
+                pass
         return port
 
     @property


### PR DESCRIPTION
This would appear as:
```
  File "/home/jking/pyvmomi/.eggs/vcrpy-2.0.1-py3.6.egg/vcr/request.py", line 61, in port
    port = {'https': 443, 'http': 80}[parse_uri.scheme]
KeyError: ''
```

Changes were made in #389 to allow for CONNECT (tunneling), and also OPTIONS (with path '*') would also work using the same logic.  In these cases, the vcr.Request class will store the URI of the request as the contents of the path verbatim (not a uri).

When the cassette replays, there was code to parse the port which was throwing an uncaught exception.  The code used to expect all uri to begin with either 'https' or 'http'.  Now if the uri does not start with those, the port remains `None` instead of generating a `KeyError`.

Added a unit test to prove this as well.

This fixes #414 