### PR TITLE
Fix collections.abc DeprecationWarning

### DIFF
--- a/vcr/util.py
+++ b/vcr/util.py
@@ -1,13 +1,17 @@
-import collections
 import types
+
+try:
+    from collections.abc import Mapping, MutableMapping
+except ImportError:
+    from collections import Mapping, MutableMapping
 
 
 # Shamelessly stolen from https://github.com/kennethreitz/requests/blob/master/requests/structures.py
-class CaseInsensitiveDict(collections.MutableMapping):
+class CaseInsensitiveDict(MutableMapping):
     """
     A case-insensitive ``dict``-like object.
     Implements all methods and operations of
-    ``collections.MutableMapping`` as well as dict's ``copy``. Also
+    ``collections.abc.MutableMapping`` as well as dict's ``copy``. Also
     provides ``lower_items``.
     All keys are expected to be strings. The structure remembers the
     case of the last key to be set, and ``iter(instance)``,
@@ -57,7 +61,7 @@ class CaseInsensitiveDict(collections.MutableMapping):
         )
 
     def __eq__(self, other):
-        if isinstance(other, collections.Mapping):
+        if isinstance(other, Mapping):
             other = CaseInsensitiveDict(other)
         else:
             return NotImplemented


### PR DESCRIPTION
In versions of Python from 3.8 and forward, importing Mapping and
MutableMapping from the collections module will no longer work. This
change will try to import from the collections.abc module, which was
added in Python 3.3, and fall back to the collections module on older
versions of Python.

Fixes #401.