### PR TITLE
Fix exception when body of request is empty.

### DIFF
--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -136,6 +136,23 @@ def test_replace_post_data_parameters():
     assert request.body == b"one=keep&three=tada&four=SHOUT"
 
 
+def test_replace_post_data_parameters_empty_body():
+    # This test ensures replace_post_data_parameters doesn't throw exception when body is empty.
+    body = None
+    request = Request("POST", "http://google.com", body, {})
+    replace_post_data_parameters(
+        request,
+        [
+            ("two", None),
+            ("three", "tada"),
+            ("four", lambda key, value, request: value.upper()),
+            ("five", lambda key, value, request: None),
+            ("six", "doesntexist"),
+        ],
+    )
+    assert request.body is None
+
+
 def test_remove_post_data_parameters():
     # Test the backward-compatible API wrapper.
     body = b"id=secret&foo=bar"

--- a/vcr/filters.py
+++ b/vcr/filters.py
@@ -82,6 +82,10 @@ def replace_post_data_parameters(request, replacements):
       3. A callable which accepts (key, value, request) and returns a string
          value or None.
     """
+    if not request.body:
+        # Nothing to replace
+        return request
+
     replacements = dict(replacements)
     if request.method == "POST" and not isinstance(request.body, BytesIO):
         if request.headers.get("Content-Type") == "application/json":


### PR DESCRIPTION
This happens, for example if a POST request is used to initiate some
action, but doesn't require any BODY.