### PR TITLE
aiohttp stub incorrectly expects recorded response to have a URL

### DIFF
--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -57,7 +57,7 @@ def vcr_request(cassette, real_request):
         if cassette.can_play_response_for(vcr_request):
             vcr_response = cassette.play_response(vcr_request)
 
-            response = MockClientResponse(method, URL(vcr_response.get('url')))
+            response = MockClientResponse(method, request_url)
             response.status = vcr_response['status']['code']
             response._body = vcr_response['body']['string']
             response.reason = vcr_response['status']['message']


### PR DESCRIPTION
When I try to play cassettes with aiohttp (3.5.4), I get a `TypeError` from the `yarl.URL` constructor when it's called in the [aiohttp_stubs](https://github.com/kevin1024/vcrpy/blob/master/vcr/stubs/aiohttp_stubs/__init__.py#L60):
```py
response = MockClientResponse(method, URL(vcr_response.get('url')))
```
So far as I can tell, `vcr_response.get('url')` is always `None` because cassette responses don't include a URL. The `yarl.URL` constructor expects a string, hence the `TypeError`.

I think the intent here was to attach the request URL, which we already have above on line 49, to the `MockClientResponse`, so here's a patch to do that. It solves the problem for me but please let me know if there's a better solution, it's possible I've missed something here.