### PR TITLE
Drop support for EOL Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 before_install: openssl version
 env:
   global:
@@ -18,37 +17,27 @@ matrix:
     - env: TOX_SUFFIX="flakes"
       python: 3.7
       dist: xenial
-      sudo: true
     - env: TOX_SUFFIX="requests27"
       python: 3.7
       dist: xenial
-      sudo: true
     - env: TOX_SUFFIX="httplib2"
       python: 3.7
       dist: xenial
-      sudo: true
     - env: TOX_SUFFIX="urllib3121"
       python: 3.7
       dist: xenial
-      sudo: true
     - env: TOX_SUFFIX="tornado4"
       python: 3.7
       dist: xenial
-      sudo: true
     - env: TOX_SUFFIX="aiohttp"
       python: 3.7
       dist: xenial
-      sudo: true
   allow_failures:
     - env: TOX_SUFFIX="boto3"
     - env: TOX_SUFFIX="aiohttp"
       python: "pypy3.5-5.9.0"
-    - env: TOX_SUFFIX="aiohttp"
-      python: 3.4
   exclude:
     # Only run flakes on a single Python 2.x and a single 3.x
-    - env: TOX_SUFFIX="flakes"
-      python: 3.4
     - env: TOX_SUFFIX="flakes"
       python: 3.5
     - env: TOX_SUFFIX="flakes"
@@ -61,7 +50,6 @@ matrix:
       python: pypy
 python:
 - 2.7
-- 3.4
 - 3.5
 - 3.6
 - pypy

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,7 +9,7 @@ with pip::
 Compatibility
 -------------
 
-VCR.py supports Python 2.7 and 3.4+, and
+VCR.py supports Python 2.7 and 3.5+, and
 `pypy <http://pypy.org>`__.
 
 The following HTTP libraries are supported:

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,7 @@ install_requires = [
     'six>=1.5',
     'contextlib2; python_version=="2.7"',
     'mock; python_version=="2.7"',
-    'yarl; python_version>"3.4"',
-    'yarl<1.0.0; python_version=="3.4"',
-    'multidict<4.0.0,>=2.0; python_version=="3.4"'
+    'yarl; python_version>"3.5"',
 ]
 
 excluded_packages = ["tests*"]
@@ -49,7 +47,7 @@ setup(
     author_email='me@kevinmccarthy.org',
     url='https://github.com/kevin1024/vcrpy',
     packages=find_packages(exclude=excluded_packages),
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     install_requires=install_requires,
     license='MIT',
     tests_require=['pytest', 'mock', 'pytest-httpbin'],
@@ -61,7 +59,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tests/integration/test_proxy.py
+++ b/tests/integration/test_proxy.py
@@ -44,7 +44,7 @@ def proxy_server():
         target=httpd.serve_forever,
     )
     proxy_process.start()
-    yield 'http://{0}:{1}'.format(*httpd.server_address)
+    yield 'http://{}:{}'.format(*httpd.server_address)
     proxy_process.terminate()
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36,py37,pypy}-{flakes,requests27,httplib2,urllib3121,tornado4,boto3,aiohttp}
+envlist = {py27,py35,py36,py37,pypy}-{flakes,requests27,httplib2,urllib3121,tornado4,boto3,aiohttp}
 
 [testenv:flakes]
 skipsdist = True

--- a/vcr/migration.py
+++ b/vcr/migration.py
@@ -159,9 +159,9 @@ def main():
                  for (root, dirs, files) in os.walk(path)
                  for name in files)
     for file_path in files:
-            migrated = try_migrate(file_path)
-            status = 'OK' if migrated else 'FAIL'
-            sys.stderr.write("[{}] {}\n".format(status, file_path))
+        migrated = try_migrate(file_path)
+        status = 'OK' if migrated else 'FAIL'
+        sys.stderr.write("[{}] {}\n".format(status, file_path))
     sys.stderr.write("Done.\n")
 
 

--- a/vcr/migration.py
+++ b/vcr/migration.py
@@ -68,7 +68,7 @@ def _migrate(data):
     for item in data:
         req = item['request']
         res = item['response']
-        uri = dict((k, req.pop(k)) for k in PARTS)
+        uri = {k: req.pop(k) for k in PARTS}
         req['uri'] = build_uri(**uri)
         # convert headers to dict of lists
         headers = req['headers']
@@ -100,7 +100,7 @@ def migrate_json(in_fp, out_fp):
 
 
 def _list_of_tuples_to_dict(fs):
-    return dict((k, v) for k, v in fs[0])
+    return {k: v for k, v in fs[0]}
 
 
 def _already_migrated(data):

--- a/vcr/request.py
+++ b/vcr/request.py
@@ -91,7 +91,7 @@ class Request(object):
             'method': self.method,
             'uri': self.uri,
             'body': self.body,
-            'headers': dict(((k, [v]) for k, v in self.headers.items())),
+            'headers': {k: [v] for k, v in self.headers.items()},
         }
 
     @classmethod

--- a/vcr/stubs/__init__.py
+++ b/vcr/stubs/__init__.py
@@ -139,7 +139,7 @@ class VCRConnection(object):
         if url and not url.startswith('/'):
             # Then this must be a proxy request.
             return url
-        uri = "{0}://{1}{2}{3}".format(
+        uri = "{}://{}{}{}".format(
             self._protocol,
             self.real_connection.host,
             self._port_postfix(),

--- a/vcr/util.py
+++ b/vcr/util.py
@@ -118,10 +118,10 @@ def auto_decorate(
             )
 
         def __new__(cls, name, bases, attributes_dict):
-            new_attributes_dict = dict(
-                (attribute, maybe_decorate(attribute, value))
+            new_attributes_dict = {
+                attribute: maybe_decorate(attribute, value)
                 for attribute, value in attributes_dict.items()
-            )
+            }
             return super(DecorateAll, cls).__new__(
                 cls, name, bases, new_attributes_dict
             )


### PR DESCRIPTION
Python 3.4 is EOL and no longer receiving security updates (or any updates) from the core Python team since 2019-03-16.

Source: https://en.wikipedia.org/wiki/CPython#Version_history

Here's the pip installs for vcrpy from PyPI for April 2019:

| category | percent | downloads |
|----------|--------:|----------:|
|      3.6 |  34.62% |    54,167 |
|      3.7 |  28.32% |    44,318 |
|      2.7 |  23.90% |    37,405 |
|      3.5 |  10.45% |    16,359 |
|      3.4 |   1.65% |     2,575 |
| null     |   0.61% |       956 |
|      3.8 |   0.44% |       684 |
|      3.3 |   0.01% |        15 |
|      2.6 |   0.00% |         2 |
| Total    |         |   156,481 |

Source: `pypistats python_minor vcrpy --last-month # pip install pypistats`

It also reduces the CI matrix from 42 to 36 jobs (Total time 58 min 7 sec -> 47 min 11 sec).

This also fixes a Flake8 error.
