### PR TITLE
Minimal aiohttp streamreader support

### DIFF
--- a/tests/integration/aiohttp_utils.py
+++ b/tests/integration/aiohttp_utils.py
@@ -17,6 +17,8 @@ async def aiohttp_request(loop, method, url, output='text', encoding='utf-8', co
         content = await response.json(encoding=encoding, content_type=content_type)
     elif output == 'raw':
         content = await response.read()
+    elif output == 'stream':
+        content = await response.content.read()
 
     response_ctx._resp.close()
     await session.close()

--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -95,13 +95,12 @@ def test_binary(tmpdir, scheme):
 
 def test_stream(tmpdir, scheme):
     url = scheme + '://httpbin.org/get'
-    headers = {'Content-Type': 'application/json'}
 
     with vcr.use_cassette(str(tmpdir.join('stream.yaml'))):
-        resp, body = get(url, output='raw')  # XXX: headers?
+        resp, body = get(url, output='raw')  # Do not use stream here, as the stream is exhausted by vcr
 
     with vcr.use_cassette(str(tmpdir.join('stream.yaml'))) as cassette:
-        cassette_resp, cassette_body = get(url, output='raw')
+        cassette_resp, cassette_body = get(url, output='stream')
         assert cassette_body == body
         assert cassette.play_count == 1
 

--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -93,20 +93,15 @@ def test_binary(tmpdir, scheme):
         assert cassette.play_count == 1
 
 
-@pytest.mark.asyncio
-async def test_stream(tmpdir, scheme):
+def test_stream(tmpdir, scheme):
     url = scheme + '://httpbin.org/get'
     headers = {'Content-Type': 'application/json'}
 
     with vcr.use_cassette(str(tmpdir.join('stream.yaml'))):
-        async with aiohttp.ClientSession() as session:
-            resp = await session.get(url, headers=headers)
-            body = await resp.read()  # do not use stream interface here, the stream seems exhausted by vcr
+        resp, body = get(url, output='raw')  # XXX: headers?
 
     with vcr.use_cassette(str(tmpdir.join('stream.yaml'))) as cassette:
-        async with aiohttp.ClientSession() as session:
-            cassette_resp = await session.get(url, headers=headers)
-            cassette_body = await cassette_resp.content.read()
+        cassette_resp, cassette_body = get(url, output='raw')
         assert cassette_body == body
         assert cassette.play_count == 1
 

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -5,10 +5,14 @@ import asyncio
 import functools
 import json
 
-from aiohttp import ClientResponse
+from aiohttp import ClientResponse, streams
 from yarl import URL
 
 from vcr.request import Request
+
+
+class MockStream(asyncio.StreamReader, streams.AsyncStreamReaderMixin):
+    pass
 
 
 class MockClientResponse(ClientResponse):
@@ -36,6 +40,13 @@ class MockClientResponse(ClientResponse):
 
     def release(self):
         pass
+
+    @property
+    def content(self):
+        s = MockStream()
+        s.feed_data(self._body)
+        s.feed_eof()
+        return s
 
 
 def vcr_request(cassette, real_request):


### PR DESCRIPTION
First off, I love `vcrpy`, great work @kevin1024, thank you for giving this to the world :-)

This is a minimal-effort PR to make the MockClientResponse object contain a streamreader object that's fairly similar to the one a real aiohttp ClientResponse object contains.  I've built this as a wheel and included in my own project and this works fine for my use cases (on code that's been run hundreds or thousands of time, but has not been properly tested until now).

I'd love for this (or something based on this) could get included in `vcrpy`.  Will you take a look and let me know what you think?