### PR TITLE
Update tests related to new dependencies versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
     - secure: LBSEg/gMj4u4Hrpo3zs6Y/1mTpd2RtcN49mZIFgTdbJ9IhpiNPqcEt647Lz94F9Eses2x2WbNuKqZKZZReY7QLbEzU1m0nN5jlaKrjcG5NR5clNABfFFyhgc0jBikyS4abAG8jc2efeaTrFuQwdoF4sE8YiVrkiVj2X5Xoi6sBk=
   matrix:
     - TOX_SUFFIX="flakes"
-    - TOX_SUFFIX="requests27"
+    - TOX_SUFFIX="requests"
     - TOX_SUFFIX="httplib2"
     - TOX_SUFFIX="boto3"
     - TOX_SUFFIX="urllib3121"
@@ -17,7 +17,7 @@ matrix:
     - env: TOX_SUFFIX="flakes"
       python: 3.7
       dist: xenial
-    - env: TOX_SUFFIX="requests27"
+    - env: TOX_SUFFIX="requests"
       python: 3.7
       dist: xenial
     - env: TOX_SUFFIX="httplib2"

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -23,3 +23,24 @@ documentation <https://boto.readthedocs.io/en/latest/getting_started.html>`__
 for how to set this up. I have marked the boto tests as optional in
 Travis so you don't have to worry about them failing if you submit a
 pull request.
+
+
+Troubleshooting on MacOSX
+-------------------------
+
+If you have this kind of error when running tox :
+
+.. code:: python
+
+    __main__.ConfigurationError: Curl is configured to use SSL, but we have
+    not been able to determine which SSL backend it is using. Please see PycURL documentation for how to specify the SSL backend manually.
+
+Then you need to define some environment variables:
+
+.. code:: bash
+
+    export PYCURL_SSL_LIBRARY=openssl
+    export LDFLAGS=-L/usr/local/opt/openssl/lib
+    export CPPFLAGS=-I/usr/local/opt/openssl/include
+
+Reference : `stackoverflow issue <https://stackoverflow.com/questions/51019622/curl-is-configured-to-use-ssl-but-we-have-not-been-able-to-determine-which-ssl>`__

--- a/tests/integration/test_httplib2.py
+++ b/tests/integration/test_httplib2.py
@@ -22,7 +22,7 @@ def http():
     kwargs = {
         'ca_certs': pytest_httpbin.certs.where()
     }
-    if sys.version_info[:2] == (3, 7):
+    if sys.version_info[:2] in [(2, 7), (3, 7)]:
         kwargs['disable_ssl_certificate_validation'] = True
     return httplib2.Http(**kwargs)
 

--- a/tests/integration/test_urllib3.py
+++ b/tests/integration/test_urllib3.py
@@ -20,7 +20,7 @@ def verify_pool_mgr():
 
 @pytest.fixture(scope='module')
 def pool_mgr():
-    return urllib3.PoolManager()
+    return urllib3.PoolManager(cert_reqs='CERT_NONE')
 
 
 def test_status_code(httpbin_both, tmpdir, verify_pool_mgr):

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ deps =
     pytest
     pytest-httpbin
     PyYAML
+    ipaddress
     requests: requests>=2.22.0
     httplib2: httplib2
     urllib3121: urllib3==1.21.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py35,py36,py37,pypy}-{flakes,requests,httplib2,urllib3121,tornado4,boto3,aiohttp}
+envlist = {py27,py35,py36,py37,pypy}-{flakes,requests,httplib2,urllib3121,tornado4,boto3},{py35,py36,py37}-{aiohttp}
 
 [testenv:flakes]
 skipsdist = True


### PR DESCRIPTION
New dependencies versions are breaking the test suite, this PR update and fix the test.

Dependencies involved :  
- urllib3
- httplib2

Also, it should be nice to know why Travis-CI is not working on PR creation, @kevin1024, @lamenezes, anyone ?