### PR TITLE
Remove broken Waffle badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|PyPI| |Python versions| |Build Status| |Waffle Ready| |Gitter|
+|PyPI| |Python versions| |Build Status| |Gitter|
 
 VCR.py
 ======
@@ -53,8 +53,6 @@ more details
    :target: https://pypi.python.org/pypi/vcrpy
 .. |Build Status| image:: https://secure.travis-ci.org/kevin1024/vcrpy.svg?branch=master
    :target: http://travis-ci.org/kevin1024/vcrpy
-.. |Waffle Ready| image:: https://badge.waffle.io/kevin1024/vcrpy.svg?label=ready&title=waffle
-   :target: https://waffle.io/kevin1024/vcrpy
 .. |Gitter| image:: https://badges.gitter.im/Join%20Chat.svg
    :alt: Join the chat at https://gitter.im/kevin1024/vcrpy
    :target: https://gitter.im/kevin1024/vcrpy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge


### PR DESCRIPTION
Waffle shut down on May 16th, 2019 "due to market direction and the acquisition by Broadcom".

https://help.waffle.io/articles/2801857-waffle-shutdown-tl-dr