### PR TITLE
CannotOverwritteCassetteException: Add properties

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -11,7 +11,10 @@ yourself using `py.test <http://pytest.org/>`__ and
 all environments VCR.py supports. The test suite is pretty big and slow,
 but you can tell tox to only run specific tests like this::
 
-    tox -e py27requests -- -v -k "'test_status_code or test_gzip'"
+    tox -e {pyNN}-{HTTP_LIBRARY} -- <pytest flags passed through>
+
+    tox -e py27-requests -- -v -k "'test_status_code or test_gzip'"
+    tox -e py37-requests -- -v --last-failed
 
 This will run only tests that look like ``test_status_code`` or
 ``test_gzip`` in the test suite, and only in the python 2.7 environment

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+# https://blog.ionelmc.ro/2015/04/14/tox-tricks-and-patterns/#when-it-inevitably-leads-to-shell-scripts
+# If you are getting an INVOCATION ERROR for this script then there is 
+# a good chance you are running on Windows.
+# You can and should use WSL for running tox on Windows when it calls bash scripts.
 REQUESTS_CA_BUNDLE=`python -m pytest_httpbin.certs` py.test $*

--- a/vcr/errors.py
+++ b/vcr/errors.py
@@ -1,5 +1,7 @@
 class CannotOverwriteExistingCassetteException(Exception):
     def __init__(self, *args, **kwargs):
+        self.cassette = kwargs["cassette"]
+        self.failed_request = kwargs["failed_request"]
         message = self._get_message(kwargs["cassette"], kwargs["failed_request"])
         super(CannotOverwriteExistingCassetteException, self).__init__(message)
 


### PR DESCRIPTION
This adds the cassette and the failed request onto the thrown CannotOverwriteCassetteException