### PR TITLE
Fix all warnings

### DIFF
--- a/tests/integration/test_requests.py
+++ b/tests/integration/test_requests.py
@@ -254,7 +254,7 @@ def test_nested_cassettes_with_session_created_before_nesting(httpbin_both, tmpd
 def test_post_file(tmpdir, httpbin_both):
     '''Ensure that we handle posting a file.'''
     url = httpbin_both + '/post'
-    with vcr.use_cassette(str(tmpdir.join('post_file.yaml'))) as cass, open('tox.ini') as f:
+    with vcr.use_cassette(str(tmpdir.join('post_file.yaml'))) as cass, open('tox.ini', 'rb') as f:
         original_response = requests.post(url, f).content
 
     # This also tests that we do the right thing with matching the body when they are files.

--- a/tests/integration/test_requests.py
+++ b/tests/integration/test_requests.py
@@ -116,10 +116,10 @@ def test_post_chunked_binary(tmpdir, httpbin):
     assert req1 == req2
 
 
-@pytest.mark.xskip('sys.version_info >= (3, 6)', strict=True, raises=ConnectionError)
-@pytest.mark.xskip((3, 5) < sys.version_info < (3, 6) and
-                   platform.python_implementation() == 'CPython',
-                   reason='Fails on CPython 3.5')
+@pytest.mark.skipif('sys.version_info >= (3, 6)', strict=True, raises=ConnectionError)
+@pytest.mark.skipif((3, 5) < sys.version_info < (3, 6) and
+                    platform.python_implementation() == 'CPython',
+                    reason='Fails on CPython 3.5')
 def test_post_chunked_binary_secure(tmpdir, httpbin_secure):
     '''Ensure that we can send chunked binary without breaking while trying to concatenate bytes with str.'''
     data1 = iter([b'data', b'to', b'send'])

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -5,6 +5,12 @@ import yaml
 
 import vcr.migration
 
+# Use the libYAML versions if possible
+try:
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
+
 
 def test_try_migrate_with_json(tmpdir):
     cassette = tmpdir.join('cassette.json').strpath
@@ -22,9 +28,9 @@ def test_try_migrate_with_yaml(tmpdir):
     shutil.copy('tests/fixtures/migration/old_cassette.yaml', cassette)
     assert vcr.migration.try_migrate(cassette)
     with open('tests/fixtures/migration/new_cassette.yaml', 'r') as f:
-        expected_yaml = yaml.load(f)
+        expected_yaml = yaml.load(f, Loader=Loader)
     with open(cassette, 'r') as f:
-        actual_yaml = yaml.load(f)
+        actual_yaml = yaml.load(f, Loader=Loader)
     assert actual_yaml == expected_yaml
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps = flake8
 commands =
     ./runtests.sh {posargs}
 deps =
-    Flask<1
+    Flask
     mock
     pytest
     pytest-httpbin

--- a/vcr/config.py
+++ b/vcr/config.py
@@ -1,5 +1,8 @@
 import copy
-import collections
+try:
+    from collections import abc as collections_abc  # only works on python 3.3+
+except ImportError:
+    import collections as collections_abc
 import functools
 import inspect
 import os
@@ -175,7 +178,7 @@ class VCR(object):
         if decode_compressed_response:
             filter_functions.append(filters.decode_response)
         if before_record_response:
-            if not isinstance(before_record_response, collections.Iterable):
+            if not isinstance(before_record_response, collections_abc.Iterable):
                 before_record_response = (before_record_response,)
             filter_functions.extend(before_record_response)
 
@@ -241,7 +244,7 @@ class VCR(object):
             filter_functions.append(self._build_ignore_hosts(hosts_to_ignore))
 
         if before_record_request:
-            if not isinstance(before_record_request, collections.Iterable):
+            if not isinstance(before_record_request, collections_abc.Iterable):
                 before_record_request = (before_record_request,)
             filter_functions.extend(before_record_request)
 


### PR DESCRIPTION
Fix all the warnings that appear when running tests.
That fixes the deprecation on collections.abc as well, in order to work with the new Python 3.8 release. 