### PR TITLE
fix IndexError when empty cassette throws CannotOverwriteCassetteException

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 dist/
 *.egg/
 .coverage
+htmlcov/
 *.egg-info/
 pytestdebug.log
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,12 +11,13 @@ deps = flake8
 
 [testenv]
 commands =
-    ./runtests.sh {posargs}
+    ./runtests.sh --cov={envsitepackagesdir}/vcr --cov-branch {posargs}
 deps =
     Flask
     mock
     pytest
     pytest-httpbin
+    pytest-cov
     PyYAML
     ipaddress
     requests: requests>=2.22.0

--- a/vcr/cassette.py
+++ b/vcr/cassette.py
@@ -311,7 +311,7 @@ class Cassette(object):
         best_matches.sort(key=lambda t: t[0], reverse=True)
         # Get the first best matches (multiple if equal matches)
         final_best_matches = []
-        previous_nb_success = best_matches[0][0]
+        previous_nb_success = 0 
         for best_match in best_matches:
             nb_success = best_match[0]
             # Do not keep matches that have 0 successes,

--- a/vcr/cassette.py
+++ b/vcr/cassette.py
@@ -311,7 +311,11 @@ class Cassette(object):
         best_matches.sort(key=lambda t: t[0], reverse=True)
         # Get the first best matches (multiple if equal matches)
         final_best_matches = []
-        previous_nb_success = 0 
+
+        if not best_matches:
+            return final_best_matches
+
+        previous_nb_success = best_matches[0][0]
         for best_match in best_matches:
             nb_success = best_match[0]
             # Do not keep matches that have 0 successes,


### PR DESCRIPTION
# Context

 - No cassette recorded as yet
 - pytest default is `--vcr-record=none`
 - Attempt to request in write_protected mode to prove test suite fails

Fails with IndexError instead of CannotOverwriteCassetteException