### PR TITLE
Use primitive types when recording cassettes using aiohttp stub

### DIFF
--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -56,6 +56,8 @@ def test_headers(tmpdir, scheme):
         cassette_response, _ = get(url)
         assert cassette_response.headers == response.headers
         assert cassette.play_count == 1
+        assert 'istr' not in cassette.data[0]
+        assert 'yarl.URL' not in cassette.data[0]
 
 
 def test_text(tmpdir, scheme):

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -98,9 +98,9 @@ def vcr_request(cassette, real_request):
                 'code': response.status,
                 'message': response.reason,
             },
-            'headers': dict(response.headers),
+            'headers': {str(key): value for key, value in response.headers.items()},
             'body': {'string': (await response.read())},  # NOQA: E999
-            'url': response.url,
+            'url': str(response.url),
         }
         cassette.append(vcr_request, vcr_response)
 


### PR DESCRIPTION
Fixes #405 

Cassettes generated by vcrpy using aiohttp before this PR:

```yaml
    headers:
      ? !!python/object/new:multidict._istr.istr [Access-Control-Allow-Credentials]
      : 'true'
      ? !!python/object/new:multidict._istr.istr [Access-Control-Allow-Origin]
      : '*'
      ? !!python/object/new:multidict._istr.istr [Connection]
      : keep-alive
      ? !!python/object/new:multidict._istr.istr [Content-Length]
      : '324'
      ? !!python/object/new:multidict._istr.istr [Content-Type]
      : application/json
      ? !!python/object/new:multidict._istr.istr [Date]
      : Tue, 06 Nov 2018 17:43:25 GMT
      ? !!python/object/new:multidict._istr.istr [Server]
      : gunicorn/19.9.0
      ? !!python/object/new:multidict._istr.istr [Via]
      : 1.1 vegur
    status: {code: 200, message: OK}
    url: !!python/object/new:yarl.URL
      state: !!python/tuple
      - !!python/object/new:urllib.parse.SplitResult [https, httpbin.org, /get, '',
        '']
```

After:

```yaml
    headers:                                     
      Access-Control-Allow-Credentials: 'true'   
      Access-Control-Allow-Origin: '*'           
      Connection: keep-alive                     
      Content-Length: '0'                        
      Content-Type: text/html; charset=utf-8     
      Date: Thu, 04 Jul 2019 02:54:19 GMT        
      Referrer-Policy: no-referrer-when-downgrade
      Server: nginx                              
      X-Content-Type-Options: nosniff            
      X-Frame-Options: DENY                      
      X-XSS-Protection: 1; mode=block            
    status:                                      
      code: 200                                  
      message: OK                                
    url: https://httpbin.org/status/200          
```