### PR TITLE
Fix aiohttp stub to record intermediary redirect responses properly

### DIFF
--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -223,3 +223,18 @@ def test_aiohttp_test_client_json(aiohttp_client, tmpdir):
     response_json = loop.run_until_complete(response.json())
     assert response_json is None
     assert cassette.play_count == 1
+
+
+def test_redirect(aiohttp_client, tmpdir):
+    url = 'https://httpbin.org/redirect/2'
+
+    with vcr.use_cassette(str(tmpdir.join('redirect.yaml'))):
+        response, _ = get(url)
+
+    with vcr.use_cassette(str(tmpdir.join('redirect.yaml'))) as cassette:
+        cassette_response, _ = get(url)
+
+        assert cassette_response.status == response.status
+        assert len(cassette_response.history) == len(response.history)
+        assert len(cassette) == 3
+        assert cassette.play_count == 3


### PR DESCRIPTION
Currently the aiohttp stub doesn't record intermediary redirect responses.

For example when performing a PATCH request to `https://httpbin.org/redirect-to?url=/anything&status_code=303` the client actually executes two requests and obtains two responses: the first with a 303 status code and other with 200. Therefore the cassette should contain both pairs of request/response (example below).

Also, I had to perform a little refactoring on the stub to separate some tasks to be re-used when constructing the redirect responses. 

Recorded cassette before this PR (contains only the last request and response):

```yaml
interactions:
- request:
    body: '{"i": "karai"}'
    headers:
      Content-Type:
      - application/json
    method: PATCH
    uri: https://httpbin.davecheney.com/redirect-to?url=http://httpbin.org/anything&status_code=303
  response:
    body:
      string: "{\n  \"args\": {}, \n  \"data\": \"\", \n  \"files\": {}, \n  \"form\"\
        : {}, \n  \"headers\": {\n    \"Accept\": \"*/*\", \n    \"Accept-Encoding\"\
        : \"gzip, deflate\", \n    \"Content-Type\": \"application/json\", \n    \"\
        Host\": \"httpbin.org\", \n    \"User-Agent\": \"Python/3.7 aiohttp/3.5.4\"\
        \n  }, \n  \"json\": null, \n  \"method\": \"GET\", \n  \"origin\": \"201.68.154.14,\
        \ 201.68.154.14\", \n  \"url\": \"https://httpbin.org/anything\"\n}\n"
    headers:
      ? !!python/object/new:multidict._istr.istr
      - Access-Control-Allow-Credentials
      : 'true'
      ? !!python/object/new:multidict._istr.istr
      - Access-Control-Allow-Origin
      : '*'
      ? !!python/object/new:multidict._istr.istr
      - Connection
      : keep-alive
      ? !!python/object/new:multidict._istr.istr
      - Content-Encoding
      : gzip
      ? !!python/object/new:multidict._istr.istr
      - Content-Length
      : '247'
      ? !!python/object/new:multidict._istr.istr
      - Content-Type
      : application/json
      ? !!python/object/new:multidict._istr.istr
      - Date
      : Tue, 09 Jul 2019 18:56:47 GMT
      Referrer-Policy: no-referrer-when-downgrade
      ? !!python/object/new:multidict._istr.istr
      - Server
      : nginx
      X-Content-Type-Options: nosniff
      X-Frame-Options: DENY
      X-XSS-Protection: 1; mode=block
    status:
      code: 200
      message: OK
    url: !!python/object/new:yarl.URL
      state: !!python/tuple
      - !!python/object/new:urllib.parse.SplitResult
        - http
        - httpbin.org
        - /anything
        - ''
        - ''
version: 1
```

Cassette after this PR (contains both request/response):

```yaml
interactions:
- request:
    body: '{"i": "karai"}'
    headers:
      Content-Type:
      - application/json
    method: PATCH
    uri: https://httpbin.davecheney.com/redirect-to?url=http://httpbin.org/anything&status_code=303
  response:
    body: {}
    headers:
      Access-Control-Allow-Credentials: 'true'
      Access-Control-Allow-Origin: '*'
      Content-Length: '0'
      Content-Type: text/html; charset=utf-8
      Date: Tue, 09 Jul 2019 21:52:07 GMT
      Location: http://httpbin.org/anything
      Server: envoy
      x-envoy-upstream-service-time: '3'
    status:
      code: 303
      message: See Other
    url: https://httpbin.davecheney.com/redirect-to?url=http://httpbin.org/anything&status_code=303
- request:
    body: '{"i": "karai"}'
    headers:
      Content-Type:
      - application/json
    method: PATCH
    uri: https://httpbin.davecheney.com/redirect-to?url=http://httpbin.org/anything&status_code=303
  response:
    body:
      string: "{\n  \"args\": {}, \n  \"data\": \"\", \n  \"files\": {}, \n  \"form\"\
        : {}, \n  \"headers\": {\n    \"Accept\": \"*/*\", \n    \"Accept-Encoding\"\
        : \"gzip, deflate\", \n    \"Content-Type\": \"application/json\", \n    \"\
        Host\": \"httpbin.org\", \n    \"User-Agent\": \"Python/3.7 aiohttp/3.5.4\"\
        \n  }, \n  \"json\": null, \n  \"method\": \"GET\", \n  \"origin\": \"201.68.154.14,\
        \ 201.68.154.14\", \n  \"url\": \"https://httpbin.org/anything\"\n}\n"
    headers:
      Access-Control-Allow-Credentials: 'true'
      Access-Control-Allow-Origin: '*'
      Connection: keep-alive
      Content-Encoding: gzip
      Content-Length: '247'
      Content-Type: application/json
      Date: Tue, 09 Jul 2019 21:52:08 GMT
      Referrer-Policy: no-referrer-when-downgrade
      Server: nginx
      X-Content-Type-Options: nosniff
      X-Frame-Options: DENY
      X-XSS-Protection: 1; mode=block
    status:
      code: 200
      message: OK
    url: http://httpbin.org/anything
version: 1
```