### PR TITLE
Increment version to v2.1.0 and add Python2.x deprecation warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if sys.version_info[0] == 2:
 
 setup(
     name='vcrpy',
-    version='2.0.1',
+    version='2.1.0',
     description=(
         "Automatically mock your HTTP interactions to simplify and "
         "speed up testing"

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     license='MIT',
     tests_require=['pytest', 'mock', 'pytest-httpbin'],
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
         'Intended Audience :: Developers',
         'Programming Language :: Python',

--- a/tests/unit/test_vcr_import.py
+++ b/tests/unit/test_vcr_import.py
@@ -1,0 +1,16 @@
+import sys
+
+
+def test_vcr_import_deprecation(recwarn):
+
+    if 'vcr' in sys.modules:
+        # Remove imported module entry if already loaded in another test
+        del sys.modules['vcr']
+
+    import vcr  # noqa: F401
+
+    if sys.version_info[0] == 2:
+        assert len(recwarn) == 1
+        assert issubclass(recwarn[0].category, DeprecationWarning)
+    else:
+        assert len(recwarn) == 0

--- a/vcr/__init__.py
+++ b/vcr/__init__.py
@@ -1,4 +1,6 @@
 import logging
+import warnings
+import sys
 from .config import VCR
 
 # Set default logging handler to avoid "No handler found" warnings.
@@ -9,6 +11,11 @@ except ImportError:
         def emit(self, record):
             pass
 
+if sys.version_info[0] == 2:
+    warnings.warn(
+        "Python 2.x support of vcrpy is deprecated and will be removed in an upcoming major release.",
+        DeprecationWarning
+    )
 
 logging.getLogger(__name__).addHandler(NullHandler())
 


### PR DESCRIPTION
 - Increment version to v2.1.0 to close out #447 
 - Add deprecation warning as a precursor to merging #443 in v3.x.x of VCRpy
 - Add test to ensure deprecation warning is only on Python2