### PR TITLE
Collect and aggregate code coverage across all test environments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 75
+        # Allow 0% coverage regression
+        threshold: 0

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 dist/
 *.egg/
 .coverage
+coverage.xml
 htmlcov/
 *.egg-info/
 pytestdebug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ matrix:
       python: 3.7
       dist: xenial
   allow_failures:
-    - env: TOX_SUFFIX="boto3"
     - env: TOX_SUFFIX="aiohttp"
       python: "pypy3.5-5.9.0"
   exclude:
@@ -58,6 +57,6 @@ install:
 - pip install tox-travis codecov
 - if [[ $TOX_SUFFIX != 'flakes' ]]; then python setup.py install ; fi
 script:
-- tox -r -e "${TOX_SUFFIX}"
+- tox -e "${TOX_SUFFIX}"
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,6 @@ install:
 - pip install tox-travis codecov
 - if [[ $TOX_SUFFIX != 'flakes' ]]; then python setup.py install ; fi
 script:
-- tox -e "${TOX_SUFFIX}"
+- tox -r -e "${TOX_SUFFIX}"
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 before_install: openssl version
 env:
-  global:
-    - secure: AifoKzwhjV94cmcQZrdQmqRu/9rkZZvWpwBv1daeAQpLOKFPGsOm3D+x2cSw9+iCfkgDZDfqQVv1kCaFVxTll8v8jTq5SJdqEY0NmGWbj/UkNtShh609oRDsuzLxAEwtVKYjf/h8K2BRea+bl1tGkwZ2vtmYS6dxNlAijjWOfds=
-    - secure: LBSEg/gMj4u4Hrpo3zs6Y/1mTpd2RtcN49mZIFgTdbJ9IhpiNPqcEt647Lz94F9Eses2x2WbNuKqZKZZReY7QLbEzU1m0nN5jlaKrjcG5NR5clNABfFFyhgc0jBikyS4abAG8jc2efeaTrFuQwdoF4sE8YiVrkiVj2X5Xoi6sBk=
+  # global:
+    # - secure: AifoKzwhjV94cmcQZrdQmqRu/9rkZZvWpwBv1daeAQpLOKFPGsOm3D+x2cSw9+iCfkgDZDfqQVv1kCaFVxTll8v8jTq5SJdqEY0NmGWbj/UkNtShh609oRDsuzLxAEwtVKYjf/h8K2BRea+bl1tGkwZ2vtmYS6dxNlAijjWOfds=
+    # - secure: LBSEg/gMj4u4Hrpo3zs6Y/1mTpd2RtcN49mZIFgTdbJ9IhpiNPqcEt647Lz94F9Eses2x2WbNuKqZKZZReY7QLbEzU1m0nN5jlaKrjcG5NR5clNABfFFyhgc0jBikyS4abAG8jc2efeaTrFuQwdoF4sE8YiVrkiVj2X5Xoi6sBk=
   matrix:
     - TOX_SUFFIX="flakes"
     - TOX_SUFFIX="requests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,9 @@ python:
 - pypy
 - "pypy3.5-5.9.0"
 install:
-- pip install tox-travis
+- pip install tox-travis codecov
 - if [[ $TOX_SUFFIX != 'flakes' ]]; then python setup.py install ; fi
 script:
 - tox -e "${TOX_SUFFIX}"
+after_success:
+  - codecov

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|PyPI| |Python versions| |Build Status| |Gitter|
+|PyPI| |Python versions| |Build Status| |CodeCov| |Gitter| 
 
 VCR.py
 ======
@@ -56,3 +56,7 @@ more details
 .. |Gitter| image:: https://badges.gitter.im/Join%20Chat.svg
    :alt: Join the chat at https://gitter.im/kevin1024/vcrpy
    :target: https://gitter.im/kevin1024/vcrpy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+.. |CodeCov| image:: https://codecov.io/gh/kevin1024/vcrpy/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/kevin1024/vcrpy
+   :alt: Code Coverage Status
+   

--- a/tests/integration/test_boto3.py
+++ b/tests/integration/test_boto3.py
@@ -26,6 +26,12 @@ boto3_skip_awsrequest = pytest.mark.skipif(
     reason='botocore version {ver} still uses vendored requests.'.format(
         ver=botocore.__version__))
 
+boto3_skip_travis_pullrequest = pytest.mark.skipif(
+    os.environ.get("TRAVIS_PULL_REQUEST") != "false",
+    reason="Encrypted Environment Variables from Travis Repository Settings"
+    " are disabled on PRs from forks. "
+    "https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions"
+)
 
 IAM_USER_NAME = "vcrpy"
 
@@ -69,6 +75,12 @@ def test_boto_vendored_stubs(tmpdir):
         VerifiedHTTPSConnection('hostname.does.not.matter')
 
 
+@pytest.mark.skipif(
+    os.environ.get("TRAVIS_PULL_REQUEST") != "false",
+    reason="Encrypted Environment Variables from Travis Repository Settings"
+    " are disabled on PRs from forks. "
+    "https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions"
+)
 def test_boto_medium_difficulty(tmpdir, get_user):
 
     with vcr.use_cassette(str(tmpdir.join('boto3-medium.yml'))):
@@ -81,6 +93,12 @@ def test_boto_medium_difficulty(tmpdir, get_user):
         assert cass.all_played
 
 
+@pytest.mark.skipif(
+    os.environ.get("TRAVIS_PULL_REQUEST") != "false",
+    reason="Encrypted Environment Variables from Travis Repository Settings"
+    " are disabled on PRs from forks. "
+    "https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions"
+)
 def test_boto_hardcore_mode(tmpdir, iam_client, get_user):
     with vcr.use_cassette(str(tmpdir.join('boto3-hardcore.yml'))):
         ses = boto3.Session(

--- a/tests/integration/test_boto3.py
+++ b/tests/integration/test_boto3.py
@@ -26,13 +26,6 @@ boto3_skip_awsrequest = pytest.mark.skipif(
     reason='botocore version {ver} still uses vendored requests.'.format(
         ver=botocore.__version__))
 
-boto3_skip_travis_pullrequest = pytest.mark.skipif(
-    os.environ.get("TRAVIS_PULL_REQUEST") != "false",
-    reason="Encrypted Environment Variables from Travis Repository Settings"
-    " are disabled on PRs from forks. "
-    "https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions"
-)
-
 IAM_USER_NAME = "vcrpy"
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps = flake8
 # for aggregate code coverage combine
 usedevelop=true
 commands =
-    ./runtests.sh --cov=./vcr --cov-branch --cov-append {posargs}
+    ./runtests.sh --cov=./vcr --cov-branch --cov-report=xml --cov-append {posargs}
 deps =
     Flask
     mock

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,21 @@
 [tox]
-envlist = {py27,py35,py36,py37,pypy}-{flakes,requests,httplib2,urllib3,tornado4,boto3},{py35,py36,py37}-{aiohttp}
+skip_missing_interpreters=true
+envlist = cov-clean,{py27,py35,py36,py37,pypy}-{flakes,requests,httplib2,urllib3,tornado4,boto3},{py35,py36,py37}-{aiohttp},cov-report
+
+
+# Coverage environment tasks: cov-clean and cov-report
+# https://pytest-cov.readthedocs.io/en/latest/tox.html
+[testenv:cov-clean]
+deps = coverage
+skip_install=true
+commands = coverage erase
+
+[testenv:cov-report]
+deps = coverage
+skip_install=true
+commands = 
+  coverage html
+  coverage report --fail-under=75
 
 [testenv:flakes]
 skipsdist = True
@@ -10,8 +26,11 @@ commands =
 deps = flake8
 
 [testenv]
+# Need to use develop install so that paths
+# for aggregate code coverage combine
+usedevelop=true
 commands =
-    ./runtests.sh --cov={envsitepackagesdir}/vcr --cov-branch {posargs}
+    ./runtests.sh --cov=./vcr --cov-branch --cov-append {posargs}
 deps =
     Flask
     mock
@@ -31,9 +50,13 @@ deps =
     aiohttp: aiohttp
     aiohttp: pytest-asyncio
     aiohttp: pytest-aiohttp
+depends = 
+  {py27,py35,py36,py37,pypy}-{flakes,requests,httplib2,urllib3,tornado4,boto3},{py35,py36,py37}-{aiohttp}: cov-clean
+  cov-report: {py27,py35,py36,py37,pypy}-{flakes,requests,httplib2,urllib3,tornado4,boto3},{py35,py36,py37}-{aiohttp}
 passenv =
     AWS_ACCESS_KEY_ID
     AWS_DEFAULT_REGION
     AWS_SECRET_ACCESS_KEY
+
 [flake8]
 max_line_length = 110


### PR DESCRIPTION
Investigating code coverage reporting.


 - Create `cov-clean` tox environment
 - Create `cov-report` tox environment
 - All other test environments depend upon `cov-clean`. 
 - `cov-report` depends on all test-environments.
 - `usedevelop` to install vcrpy so that the paths to the original source files are the same across tox environments to accumulate test coverage. Some paths only occur in certain environments.

For example:

Module | statements | missing | excluded | branches | partial | coverage
-- | -- | -- | -- | -- | -- | --
`vcr/__init__.py` | 11 | 4 | 0 | 0 | 0 | 64%
`vcr/_handle_coroutine.py` | 3 | 2 | 0 | 0 | 0 | 33%
`vcr/cassette.py` | 201 | 5 | 0 | 60 | 1 | 98%
... | ... | ... | ... | ... | ... | ...
`vcr/util.py` | 63 | 1 | 0 | 22 | 2 | 96%
**Total** | 1522 | 128 | 68 | 434 | 31 | **90%**

TODO:
 - [x] Aggregate across travis and enforce no code coverage regressions
    - Not necessary. CI runs the build then uploads to CodeCov
 - [x] Investigate alternatives:
    - ~~https://coveralls.io/~~ Terrible documentation.
    - https://codecov.io/ 
 - [x] `boto3` is not an allowed failure
 - [x] `boto3` selectively skips on PRs from forks in Travis. But owner branches do not skip these tests due to how Travis manages ownership credentials.
 - [ ] ~~PRs should fail on CodeCoverage regressions.~~
    - Can't test this until a `master` prior to the PR gets a run with travis uploaded to codecov.
    - Tried testing on my fork `neozenith/vcrpy` and codecov integration is not working at all.
