### PR TITLE
aiohttp headers are case insensitive

### DIFF
--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -76,6 +76,7 @@ def test_case_insensitive_headers(tmpdir, scheme):
         assert "content-type" in cassette_response.headers
         assert cassette.play_count == 1
 
+
 def test_text(tmpdir, scheme):
     url = scheme + '://httpbin.org'
     with vcr.use_cassette(str(tmpdir.join('text.yaml'))):

--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -59,11 +59,22 @@ def test_headers(tmpdir, scheme, auth):
             request = cassette.requests[0]
             assert "AUTHORIZATION" in request.headers
         cassette_response, _ = get(url, auth=auth)
-        assert cassette_response.headers == response.headers
+        assert dict(cassette_response.headers) == dict(response.headers)
         assert cassette.play_count == 1
         assert 'istr' not in cassette.data[0]
         assert 'yarl.URL' not in cassette.data[0]
 
+
+def test_case_insensitive_headers(tmpdir, scheme):
+    url = scheme + '://httpbin.org'
+    with vcr.use_cassette(str(tmpdir.join('whatever.yaml'))):
+        _, _ = get(url)
+
+    with vcr.use_cassette(str(tmpdir.join('whatever.yaml'))) as cassette:
+        cassette_response, _ = get(url)
+        assert "Content-Type" in cassette_response.headers
+        assert "content-type" in cassette_response.headers
+        assert cassette.play_count == 1
 
 def test_text(tmpdir, scheme):
     url = scheme + '://httpbin.org'

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -7,6 +7,7 @@ import logging
 import json
 
 from aiohttp import ClientResponse, streams
+from multidict import CIMultiDict, CIMultiDictProxy
 from yarl import URL
 
 from vcr.request import Request
@@ -61,7 +62,7 @@ def build_response(vcr_request, vcr_response, history):
     response.status = vcr_response['status']['code']
     response._body = vcr_response['body'].get('string', b'')
     response.reason = vcr_response['status']['message']
-    response._headers = vcr_response['headers']
+    response._headers = CIMultiDictProxy(CIMultiDict(vcr_response['headers']))
     response._history = tuple(history)
 
     response.close()


### PR DESCRIPTION
Right now, the mocked version of ClientResponse we receive using records from aiohttp are using plain dict, which doesn't follow the "case-insensitive" contract of aiohttp.

To fix that, I used CIMultiDict and CIMultiDictProxy, which is the exact type used inside aiohttp.

Used in their code:
https://github.com/aio-libs/aiohttp/blob/c6e40e78ae8de51c02b5a17b8e5e882c910d3770/aiohttp/client_reqrep.py#L280
https://github.com/aio-libs/aiohttp/blob/c6e40e78ae8de51c02b5a17b8e5e882c910d3770/aiohttp/client_reqrep.py#L312

Used in their tests:
https://github.com/aio-libs/aiohttp/blob/b3b931a9e8a619d9d642093fc17cb375d1f45d34/tests/test_web_response.py#L1088

Side note: This structure does the comparison using order (not like dict, that doesn't use order of keyrs to compare), it's why I wrapped the headers into "dict" for "test_headers", since order of headers doesn't match actual request and recorded mocked response.