### PR TITLE
Add travis testing support for python 3.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ coverage.xml
 htmlcov/
 *.egg-info/
 pytestdebug.log
+pip-wheel-metadata/
+.python-version
 
 fixtures/
 /docs/_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
   allow_failures:
     - env: TOX_SUFFIX="aiohttp"
       python: "pypy3"
-    - python: "py3.8-dev"
+    - python: "3.8-dev"
   exclude:
     # Exclude aiohttp support
     - env: TOX_SUFFIX="aiohttp"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
   allow_failures:
     - env: TOX_SUFFIX="aiohttp"
       python: "pypy3"
+    - python: "py3.8-dev"
   exclude:
     # Exclude aiohttp support
     - env: TOX_SUFFIX="aiohttp"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,27 @@ matrix:
     - env: TOX_SUFFIX="aiohttp"
       python: 3.7
       dist: xenial
+    - env: TOX_SUFFIX="lint"
+      python: 3.8-dev
+      dist: xenial
+    - env: TOX_SUFFIX="requests"
+      python: 3.8-dev
+      dist: xenial
+    - env: TOX_SUFFIX="httplib2"
+      python: 3.8-dev
+      dist: xenial
+    - env: TOX_SUFFIX="boto3"
+      python: 3.8-dev
+      dist: xenial
+    - env: TOX_SUFFIX="urllib3"
+      python: 3.8-dev
+      dist: xenial
+    - env: TOX_SUFFIX="tornado4"
+      python: 3.8-dev
+      dist: xenial
+    - env: TOX_SUFFIX="aiohttp"
+      python: 3.8-dev
+      dist: xenial
   allow_failures:
     - env: TOX_SUFFIX="aiohttp"
       python: "pypy3"

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -27,6 +27,38 @@ for how to set this up. I have marked the boto tests as optional in
 Travis so you don't have to worry about them failing if you submit a
 pull request.
 
+Using PyEnv with VCR's test suite
+---------------------------------
+
+PyEnv is a tool for managing multiple installation of python on your system.
+See the full documentation at their `github <https://github.com/pyenv/pyenv>` 
+but we are also going to use `tox-pyenv <https://pypi.org/project/tox-pyenv/>` 
+in this example::
+
+    git clone https://github.com/pyenv/pyenv ~/.pyenv
+
+    # Add ~/.pyenv/bin to your PATH
+    export PATH="$PATH:~/.pyenv/bin"
+
+    # Setup shim paths
+    eval "$(pyenv init -)"
+
+    # Setup your local system tox tooling
+    pip install tox tox-pyenv
+
+    # Install supported versions (at time of writing), this does not activate them
+    pyenv install 2.7.10 3.5.7 3.6.9 3.7.4 3.8-dev pypy2.6-7.1.1 pypy3.6-7.1.1
+
+    # This activates them
+    pyenv local 2.7.10 3.5.7 3.6.9 3.7.4 3.8-dev pypy2.6-7.1.1 pypy3.6-7.1.1
+
+    # Run the whole test suite
+    tox
+
+    # Run the whole test suite or just part of it
+    tox -e lint
+    tox -e py37-requests
+
 
 Troubleshooting on MacOSX
 -------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps = coverage
 skip_install=true
 commands = 
   coverage html
-  coverage report --fail-under=80
+  coverage report --fail-under=90
 
 [testenv:lint]
 skipsdist = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,11 @@
 [tox]
 skip_missing_interpreters=true
-envlist = cov-clean,{py27,py35,py36,py37,pypy}-{lint,requests,httplib2,urllib3,tornado4,boto3},{py35,py36,py37}-{aiohttp},cov-report
+envlist = 
+  cov-clean,
+  lint,
+  {py27,py35,py36,py37,py38,pypy,pypy3}-{requests,httplib2,urllib3,tornado4,boto3},
+  {py35,py36,py37,py38}-{aiohttp},
+  cov-report
 
 
 # Coverage environment tasks: cov-clean and cov-report


### PR DESCRIPTION
Working through adding python3.8 testing support and fixing any broken tests.

Closes #471 

Could use advice on tidying up the test matrix in the travis.yml file