### PR TITLE
Fix Python 3.8 Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 build/
 dist/
 *.egg/
-.coverage
+.coverage*
 coverage.xml
 htmlcov/
 *.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ matrix:
   allow_failures:
     - env: TOX_SUFFIX="aiohttp"
       python: "pypy3"
-    - python: "3.8-dev"
   exclude:
     # Exclude aiohttp support
     - env: TOX_SUFFIX="aiohttp"


### PR DESCRIPTION
 - Disable allowing py38 tests to fail
 - Work through fixing tests

Getting different failures locally with tox and travis.

Travis:
 - Cython errors installing yarl

Local Tox:
 - py38-requests
 - py38-aiohttp

This is going to take a while to chip away at.