### PR TITLE
Add `pytest-recording` to the documentation as an alternative Pytest plugin

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
   - Use latest pypy3 in Travis (@hugovk)
   - Improve documentation about custom matchers (@gward)
   - Fix exception when body is empty (@keithprickett)
+  - Add `pytest-recording` to the documentation as an alternative Pytest plugin (@Stranger6667)
 -  2.1.0 - Add a `rewind` method to reset a cassette (thanks @khamidou)
    New error message with more details on why the cassette failed to play a request (thanks @arthurHamon2, @neozenith)
    Handle connect tunnel URI (thanks @jeking3)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -101,3 +101,6 @@ Pytest Integration
 
 A Pytest plugin is available here : `pytest-vcr
 <https://github.com/ktosiek/pytest-vcr>`__.
+
+Alternative plugin, that also provides network access blocking: `pytest-recording
+<https://github.com/kiwicom/pytest-recording>`__.


### PR DESCRIPTION
Closes #476 