### PR TITLE
Fix yarl version requirements

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
   - Improve documentation about custom matchers (@gward)
   - Fix exception when body is empty (@keithprickett)
   - Add `pytest-recording` to the documentation as an alternative Pytest plugin (@Stranger6667)
+  - Fix yarl and python3.5 version issue (@neozenith)
 -  2.1.0 - Add a `rewind` method to reset a cassette (thanks @khamidou)
    New error message with more details on why the cassette failed to play a request (thanks @arthurHamon2, @neozenith)
    Handle connect tunnel URI (thanks @jeking3)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ install_requires = [
     "six>=1.5",
     'contextlib2; python_version=="2.7"',
     'mock; python_version=="2.7"',
-    'yarl; python_version>="3.5"',
+    'yarl; python_version>="3.6"',
+    'yarl<1.4; python_version=="3.5"',
 ]
 
 excluded_packages = ["tests*"]


### PR DESCRIPTION
Closes #485 

So weird that `yarl` installed an alpha release on CI but not on local testing in tox. Can't get it to install 1.4 even if I want it to.

Anyway... added version check to address the upcoming version support issue where yarl 1.4 only support >3.6