### PR TITLE
aiohttp: fix multiple requests being replayed per request and add support for `request_info` on mocked responses

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,9 @@
 Changelog
 ---------
+-  3.0.0 (UNRELEASED)
+  - Fix multiple requests being replayed per single request in aiohttp stub (@nickdirienzo)
+  - Add support for `request_info` on mocked responses in aiohttp stub (@nickdirienzo)
+  - ...
 -  2.1.x (UNRELEASED)
   - ....
 -  2.1.1 

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -119,7 +119,7 @@ async def record_response(cassette, vcr_request, response):
         body = {"string": (await response.read())}
     # aiohttp raises a ClientConnectionError on reads when
     # there is no body. We can use this to know to not write one.
-    except ClientConnectionError as e:
+    except ClientConnectionError:
         body = {}
 
     vcr_response = {


### PR DESCRIPTION
This PR resolves #481 and #475, while also improving #456.

It was discovered that, for `aiohttp` specifically, when there were multiple requests recorded that looked the same, they would all be played. Looking into this further, it was because the URL we recording to was the original request's URL instead of the implicit request's that followed the redirects.

This led to the change you see here where we're recording the individual request-response chains (similar to that of other HTTP clients). We also change the explicit `while cassette.can_play_response_for(vcr_request)` to one that checks the response status codes and only performs a similar check if the code is a 3xx one.

While implementing that, I wanted to be extra sure that we had similar looking responses, so I started checking the `request_info` object. Originally, each of the mock responses do not have those objects available (I'm not sure if this is intended or not), so this PR also adds support for that. `test_redirect` was amended to include a specific check that we're returning the same `request_info` between the real one and the recorded one.

Speaking of tests, thanks to @vEpiphyte for writing `test_double_requests`, which made this issue repeatable and give me confidence that this works.

There are two concerns I have around this PR:
1. This change breaks cassettes for `aiohttp` clients where redirects are performed because how we're using the cassette is fundamentally different. It feels weird to have a major bump for this, but if we're following SemVer, that may be right --- how do you all do versioning? Happy to include the version bump in this PR if that's preferred.
2. I'm pretty skeptical of my usage of `cassette.find_requests_with_most_matches` (https://github.com/kevin1024/vcrpy/compare/master...nickdirienzo:issue-481?expand=1#diff-4636a4db24aa9f9206350b6a8e171ae1R104). While the request _should_ exist, it may not and then the assumed look up will fail hard. We do need to get the recorded request in this block, otherwise we can't have the correct `request_info`. Do y'all have ideas on how to do this more safely?

Some references that I needed along the way:
- `aiohttp` follows redirects by default: https://docs.aiohttp.org/en/stable/client_advanced.html#redirection-history
- `RequestInfo`: https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.RequestInfo