### PR TITLE
Correct mock imports. Fixes #504

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,8 +9,10 @@ All help in providing PRs to close out bug issues is appreciated. Even if that i
 
 -  UNRELEASED
     - ...
-
-
+-  4.0.2
+    - Fix mock imports as reported in #504 by @llybin. Thank you.
+-  4.0.1 
+    - Fix logo alignment for PyPI 
 -  4.0.0
     - Remove Python2 support (@hugovk)
     - Add Python 3.8 TravisCI support (@neozenith)

--- a/tests/unit/test_cassettes.py
+++ b/tests/unit/test_cassettes.py
@@ -1,13 +1,12 @@
 import contextlib
 import copy
-import inspect
-import mock
-import os
-
 import http.client as httplib
+import inspect
+import os
+from unittest import mock
+
 import pytest
 import yaml
-
 from vcr.cassette import Cassette
 from vcr.errors import UnhandledHTTPRequestError
 from vcr.patch import force_reset

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 import pytest
 

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -11,7 +11,7 @@ from vcr.filters import (
 from vcr.request import Request
 import gzip
 import json
-import mock
+from unittest import mock
 import zlib
 
 

--- a/tests/unit/test_matchers.py
+++ b/tests/unit/test_matchers.py
@@ -1,5 +1,5 @@
 import itertools
-import mock
+from unittest import mock
 
 import pytest
 

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-import mock
+from unittest import mock
 
 import pytest
 

--- a/tests/unit/test_stubs.py
+++ b/tests/unit/test_stubs.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from vcr.stubs import VCRHTTPSConnection
 from vcr.cassette import Cassette

--- a/tests/unit/test_vcr.py
+++ b/tests/unit/test_vcr.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 
 import pytest

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,6 @@ commands =
     ./runtests.sh --cov=./vcr --cov-branch --cov-report=xml --cov-append {posargs}
 deps =
     Flask
-    mock
     pytest
     pytest-httpbin
     pytest-cov

--- a/vcr/__init__.py
+++ b/vcr/__init__.py
@@ -2,7 +2,7 @@ import logging
 from .config import VCR
 from logging import NullHandler
 
-__version__ = "4.0.1"
+__version__ = "4.0.2"
 
 logging.getLogger(__name__).addHandler(NullHandler())
 

--- a/vcr/patch.py
+++ b/vcr/patch.py
@@ -2,7 +2,7 @@
 import contextlib
 import functools
 import itertools
-import mock
+from unittest import mock
 
 from .stubs import VCRHTTPConnection, VCRHTTPSConnection
 import http.client as httplib


### PR DESCRIPTION
Fixes #504 

Change imports for importing `mock`