### PR TITLE
Port aiohttp unread_data to support stream reads

### DIFF
--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -117,7 +117,8 @@ def test_stream(tmpdir, scheme):
     url = scheme + "://httpbin.org/get"
 
     with vcr.use_cassette(str(tmpdir.join("stream.yaml"))):
-        resp, body = get(url, output="raw")  # Do not use stream here, as the stream is exhausted by vcr
+        resp, body = get(url, output="stream")
+        assert len(body) > 0
 
     with vcr.use_cassette(str(tmpdir.join("stream.yaml"))) as cassette:
         cassette_resp, cassette_body = get(url, output="stream")


### PR DESCRIPTION
- Addresses #502 
- The original test actually identified the issue, so for this change it only needed to returned to the correct output
- A user will only encounter "unread" data on initial recording if they use the Streaming API, which fails today, so it leaves the primary aiohttp unchanged