### PR TITLE
fix #429: include a trailing newline in the JSON cassette format

### DIFF
--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -13,7 +13,9 @@ def test_set_serializer_default_config(tmpdir, httpbin):
         urlopen(httpbin.url + "/get")
 
     with open(str(tmpdir.join("test.json"))) as f:
-        assert json.loads(f.read())
+        file_content = f.read()
+        assert file_content.endswith("\n")
+        assert json.loads(file_content)
 
 
 def test_default_set_cassette_library_dir(tmpdir, httpbin):

--- a/vcr/serializers/jsonserializer.py
+++ b/vcr/serializers/jsonserializer.py
@@ -16,7 +16,7 @@ def serialize(cassette_dict):
     )
 
     try:
-        return json.dumps(cassette_dict, indent=4)
+        return json.dumps(cassette_dict, indent=4) + "\n"
     except UnicodeDecodeError as original:  # py2
         raise UnicodeDecodeError(
             original.encoding,


### PR DESCRIPTION
It is a common convention for text files (esp. in Linux) to end with a newline.