### PR TITLE
Do not redirect on 304 for aiohttp

### DIFF
--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -273,6 +273,23 @@ def test_redirect(aiohttp_client, tmpdir):
     assert cassette_response.request_info.real_url == response.request_info.real_url
 
 
+def test_not_modified(aiohttp_client, tmpdir):
+    """It doesn't try to redirect on 304"""
+    url = "https://httpbin.org/status/304"
+
+    with vcr.use_cassette(str(tmpdir.join("not_modified.yaml"))):
+        response, _ = get(url)
+
+    with vcr.use_cassette(str(tmpdir.join("not_modified.yaml"))) as cassette:
+        cassette_response, _ = get(url)
+
+        assert cassette_response.status == 304
+        assert response.status == 304
+        assert len(cassette_response.history) == len(response.history)
+        assert len(cassette) == 1
+        assert cassette.play_count == 1
+
+
 def test_double_requests(tmpdir):
     """We should capture, record, and replay all requests and response chains,
         even if there are duplicate ones.

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -92,6 +92,9 @@ def play_responses(cassette, vcr_request):
     # If we're following redirects, continue playing until we reach
     # our final destination.
     while 300 <= response.status <= 399:
+        if "location" not in response.headers:
+            break
+
         next_url = URL(response.url).with_path(response.headers["location"])
 
         # Make a stub VCR request that we can then use to look up the recorded


### PR DESCRIPTION
Currently VCR tries to redirect on 304 (not modified) status codes. It causes a crash because the 'location' header is not set on 304s.

I added an exception for 304s in the redirection code.