### PR TITLE
aiohttp: Add support to cookies and multiple headers with same key

### DIFF
--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+import urllib.parse
 
 import pytest
 
@@ -302,3 +303,23 @@ def test_double_requests(tmpdir):
 
         # Now that we made both requests, we should have played both.
         assert cassette.play_count == 2
+
+
+def test_cookies(scheme, tmpdir):
+    url = scheme + (
+        '://httpbin.org/response-headers?'
+        'set-cookie=' + urllib.parse.quote('cookie_1=val_1; Path=/') + '&'
+        'Set-Cookie=' + urllib.parse.quote('Cookie_2=Val_2; Path=/')
+    )
+    with vcr.use_cassette(str(tmpdir.join("cookies.yaml"))) as cassette:
+        response, _ = get(url, output='json')
+
+    assert response.cookies.get('cookie_1').value == 'val_1'
+    assert response.cookies.get('Cookie_2').value == 'Val_2'
+
+    with vcr.use_cassette(str(tmpdir.join("cookies.yaml"))) as cassette:
+        response, _ = get(url, output='json')
+        assert cassette.play_count == 1
+
+    assert response.cookies.get('cookie_1').value == 'val_1'
+    assert response.cookies.get('Cookie_2').value == 'Val_2'

--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -307,19 +307,19 @@ def test_double_requests(tmpdir):
 
 def test_cookies(scheme, tmpdir):
     url = scheme + (
-        '://httpbin.org/response-headers?'
-        'set-cookie=' + urllib.parse.quote('cookie_1=val_1; Path=/') + '&'
-        'Set-Cookie=' + urllib.parse.quote('Cookie_2=Val_2; Path=/')
+        "://httpbin.org/response-headers?"
+        "set-cookie=" + urllib.parse.quote("cookie_1=val_1; Path=/") + "&"
+        "Set-Cookie=" + urllib.parse.quote("Cookie_2=Val_2; Path=/")
     )
     with vcr.use_cassette(str(tmpdir.join("cookies.yaml"))) as cassette:
-        response, _ = get(url, output='json')
+        response, _ = get(url, output="json")
 
-    assert response.cookies.get('cookie_1').value == 'val_1'
-    assert response.cookies.get('Cookie_2').value == 'Val_2'
+    assert response.cookies.get("cookie_1").value == "val_1"
+    assert response.cookies.get("Cookie_2").value == "Val_2"
 
     with vcr.use_cassette(str(tmpdir.join("cookies.yaml"))) as cassette:
-        response, _ = get(url, output='json')
+        response, _ = get(url, output="json")
         assert cassette.play_count == 1
 
-    assert response.cookies.get('cookie_1').value == 'val_1'
-    assert response.cookies.get('Cookie_2').value == 'Val_2'
+    assert response.cookies.get("cookie_1").value == "val_1"
+    assert response.cookies.get("Cookie_2").value == "Val_2"

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -75,7 +75,7 @@ def build_response(vcr_request, vcr_response, history):
         try:
             response.cookies.load(hdr)
         except CookieError as exc:
-            log.warning('Can not load response cookies: %s', exc)
+            log.warning("Can not load response cookies: %s", exc)
 
     response.close()
     return response


### PR DESCRIPTION
This PR also partially solves #463. Each header is serialized as a list of strings but it can also deserialize from string for backwards compatibility.