### PR TITLE
aiohttp: Add support for cookies

### DIFF
--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -180,9 +180,8 @@ def test_params_same_url_distinct_params(tmpdir, scheme):
 
     other_params = {"other": "params"}
     with vcr.use_cassette(str(tmpdir.join("get.yaml"))) as cassette:
-        response, cassette_response_text = get(url, output="text", params=other_params)
-        assert "No match for the request" in cassette_response_text
-        assert response.status == 599
+        with pytest.raises(vcr.errors.CannotOverwriteExistingCassetteException):
+            get(url, output="text", params=other_params)
 
 
 def test_params_on_url(tmpdir, scheme):

--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -339,18 +339,14 @@ def test_cookies(scheme, tmpdir):
         with vcr.use_cassette(tmp) as cassette:
             async with aiohttp.ClientSession() as session:
                 cookies_resp = await session.get(cookies_url)
-                home_resp = await session.get(
-                    home_url, cookies=req_cookies, headers=req_headers
-                )
+                home_resp = await session.get(home_url, cookies=req_cookies, headers=req_headers)
         assert_responses(cookies_resp, home_resp)
 
         # -------------------------- Play --------------------------- #
         with vcr.use_cassette(tmp, record_mode="none") as cassette:
             async with aiohttp.ClientSession() as session:
                 cookies_resp = await session.get(cookies_url)
-                home_resp = await session.get(
-                    home_url, cookies=req_cookies, headers=req_headers
-                )
+                home_resp = await session.get(home_url, cookies=req_cookies, headers=req_headers)
         assert_responses(cookies_resp, home_resp)
 
     def assert_responses(cookies_resp, home_resp):

--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -364,7 +364,7 @@ def test_cookies(scheme, tmpdir):
 def test_cookies_redirect(scheme, tmpdir):
     async def run(loop):
         # Sets cookie as provided by the query string and redirects
-        cookies_url = scheme + '://httpbin.org/cookies/set?Cookie_1=Val_1'
+        cookies_url = scheme + "://httpbin.org/cookies/set?Cookie_1=Val_1"
         tmp = str(tmpdir.join("cookies.yaml"))
 
         # ------------------------- Record -------------------------- #
@@ -373,29 +373,29 @@ def test_cookies_redirect(scheme, tmpdir):
                 cookies_resp = await session.get(cookies_url)
                 assert not cookies_resp.cookies
                 cookies = session.cookie_jar.filter_cookies(cookies_url)
-                assert cookies['Cookie_1'].value == 'Val_1'
+                assert cookies["Cookie_1"].value == "Val_1"
                 assert cassette.play_count == 0
-            cassette.requests[1].headers['Cookie'] == 'Cookie_1=Val_1'
+            cassette.requests[1].headers["Cookie"] == "Cookie_1=Val_1"
 
         # -------------------------- Play --------------------------- #
-        with vcr.use_cassette(tmp, record_mode='none') as cassette:
+        with vcr.use_cassette(tmp, record_mode="none") as cassette:
             async with aiohttp.ClientSession(loop=loop) as session:
                 cookies_resp = await session.get(cookies_url)
                 assert not cookies_resp.cookies
                 cookies = session.cookie_jar.filter_cookies(cookies_url)
-                assert cookies['Cookie_1'].value == 'Val_1'
+                assert cookies["Cookie_1"].value == "Val_1"
                 assert cassette.play_count == 2
-            cassette.requests[1].headers['Cookie'] == 'Cookie_1=Val_1'
+            cassette.requests[1].headers["Cookie"] == "Cookie_1=Val_1"
 
         # Assert that it's ignoring expiration date
-        with vcr.use_cassette(tmp, record_mode='none') as cassette:
-            cassette.responses[0]['headers']['set-cookie'] = [
-                'Cookie_1=Val_1; Expires=Wed, 21 Oct 2015 07:28:00 GMT'
+        with vcr.use_cassette(tmp, record_mode="none") as cassette:
+            cassette.responses[0]["headers"]["set-cookie"] = [
+                "Cookie_1=Val_1; Expires=Wed, 21 Oct 2015 07:28:00 GMT"
             ]
             async with aiohttp.ClientSession(loop=loop) as session:
                 cookies_resp = await session.get(cookies_url)
                 assert not cookies_resp.cookies
                 cookies = session.cookie_jar.filter_cookies(cookies_url)
-                assert cookies['Cookie_1'].value == 'Val_1'
+                assert cookies["Cookie_1"].value == "Val_1"
 
     run_in_loop(run)

--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -324,19 +324,19 @@ def test_double_requests(tmpdir):
 
 def test_cookies(scheme, tmpdir):
     url = scheme + (
-        '://httpbin.org/response-headers?'
-        'set-cookie=' + urllib.parse.quote('cookie_1=val_1; Path=/') + '&'
-        'Set-Cookie=' + urllib.parse.quote('Cookie_2=Val_2; Path=/')
+        "://httpbin.org/response-headers?"
+        "set-cookie=" + urllib.parse.quote("cookie_1=val_1; Path=/") + "&"
+        "Set-Cookie=" + urllib.parse.quote("Cookie_2=Val_2; Path=/")
     )
     with vcr.use_cassette(str(tmpdir.join("cookies.yaml"))) as cassette:
-        response, _ = get(url, output='json')
+        response, _ = get(url, output="json")
 
-    assert response.cookies.get('cookie_1').value == 'val_1'
-    assert response.cookies.get('Cookie_2').value == 'Val_2'
+    assert response.cookies.get("cookie_1").value == "val_1"
+    assert response.cookies.get("Cookie_2").value == "Val_2"
 
     with vcr.use_cassette(str(tmpdir.join("cookies.yaml"))) as cassette:
-        response, _ = get(url, output='json')
+        response, _ = get(url, output="json")
         assert cassette.play_count == 1
 
-    assert response.cookies.get('cookie_1').value == 'val_1'
-    assert response.cookies.get('Cookie_2').value == 'Val_2'
+    assert response.cookies.get("cookie_1").value == "val_1"
+    assert response.cookies.get("Cookie_2").value == "Val_2"

--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -359,3 +359,43 @@ def test_cookies(scheme, tmpdir):
         assert "Cookie_4=Val_4" in request_cookies
 
     run_in_loop(run)
+
+
+def test_cookies_redirect(scheme, tmpdir):
+    async def run(loop):
+        # Sets cookie as provided by the query string and redirects
+        cookies_url = scheme + '://httpbin.org/cookies/set?Cookie_1=Val_1'
+        tmp = str(tmpdir.join("cookies.yaml"))
+
+        # ------------------------- Record -------------------------- #
+        with vcr.use_cassette(tmp) as cassette:
+            async with aiohttp.ClientSession(loop=loop) as session:
+                cookies_resp = await session.get(cookies_url)
+                assert not cookies_resp.cookies
+                cookies = session.cookie_jar.filter_cookies(cookies_url)
+                assert cookies['Cookie_1'].value == 'Val_1'
+                assert cassette.play_count == 0
+            cassette.requests[1].headers['Cookie'] == 'Cookie_1=Val_1'
+
+        # -------------------------- Play --------------------------- #
+        with vcr.use_cassette(tmp, record_mode='none') as cassette:
+            async with aiohttp.ClientSession(loop=loop) as session:
+                cookies_resp = await session.get(cookies_url)
+                assert not cookies_resp.cookies
+                cookies = session.cookie_jar.filter_cookies(cookies_url)
+                assert cookies['Cookie_1'].value == 'Val_1'
+                assert cassette.play_count == 2
+            cassette.requests[1].headers['Cookie'] == 'Cookie_1=Val_1'
+
+        # Assert that it's ignoring expiration date
+        with vcr.use_cassette(tmp, record_mode='none') as cassette:
+            cassette.responses[0]['headers']['set-cookie'] = [
+                'Cookie_1=Val_1; Expires=Wed, 21 Oct 2015 07:28:00 GMT'
+            ]
+            async with aiohttp.ClientSession(loop=loop) as session:
+                cookies_resp = await session.get(cookies_url)
+                assert not cookies_resp.cookies
+                cookies = session.cookie_jar.filter_cookies(cookies_url)
+                assert cookies['Cookie_1'].value == 'Val_1'
+
+    run_in_loop(run)

--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+import urllib.parse
 
 import pytest
 
@@ -319,3 +320,23 @@ def test_double_requests(tmpdir):
 
         # Now that we made both requests, we should have played both.
         assert cassette.play_count == 2
+
+
+def test_cookies(scheme, tmpdir):
+    url = scheme + (
+        '://httpbin.org/response-headers?'
+        'set-cookie=' + urllib.parse.quote('cookie_1=val_1; Path=/') + '&'
+        'Set-Cookie=' + urllib.parse.quote('Cookie_2=Val_2; Path=/')
+    )
+    with vcr.use_cassette(str(tmpdir.join("cookies.yaml"))) as cassette:
+        response, _ = get(url, output='json')
+
+    assert response.cookies.get('cookie_1').value == 'val_1'
+    assert response.cookies.get('Cookie_2').value == 'Val_2'
+
+    with vcr.use_cassette(str(tmpdir.join("cookies.yaml"))) as cassette:
+        response, _ = get(url, output='json')
+        assert cassette.play_count == 1
+
+    assert response.cookies.get('cookie_1').value == 'val_1'
+    assert response.cookies.get('Cookie_2').value == 'Val_2'

--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -342,7 +342,7 @@ def test_cookies(scheme, tmpdir):
         assert_responses(cookies_resp, home_resp)
 
         # -------------------------- Play --------------------------- #
-        with vcr.use_cassette(tmp, record_mode="none") as cassette:
+        with vcr.use_cassette(tmp, record_mode=vcr.mode.NONE) as cassette:
             async with aiohttp.ClientSession(loop=loop) as session:
                 cookies_resp = await session.get(cookies_url)
                 home_resp = await session.get(home_url, cookies=req_cookies, headers=req_headers)
@@ -378,7 +378,7 @@ def test_cookies_redirect(scheme, tmpdir):
             cassette.requests[1].headers["Cookie"] == "Cookie_1=Val_1"
 
         # -------------------------- Play --------------------------- #
-        with vcr.use_cassette(tmp, record_mode="none") as cassette:
+        with vcr.use_cassette(tmp, record_mode=vcr.mode.NONE) as cassette:
             async with aiohttp.ClientSession(loop=loop) as session:
                 cookies_resp = await session.get(cookies_url)
                 assert not cookies_resp.cookies
@@ -388,7 +388,7 @@ def test_cookies_redirect(scheme, tmpdir):
             cassette.requests[1].headers["Cookie"] == "Cookie_1=Val_1"
 
         # Assert that it's ignoring expiration date
-        with vcr.use_cassette(tmp, record_mode="none") as cassette:
+        with vcr.use_cassette(tmp, record_mode=vcr.mode.NONE) as cassette:
             cassette.responses[0]["headers"]["set-cookie"] = [
                 "Cookie_1=Val_1; Expires=Wed, 21 Oct 2015 07:28:00 GMT"
             ]

--- a/vcr/stubs/aiohttp_stubs.py
+++ b/vcr/stubs/aiohttp_stubs.py
@@ -75,7 +75,13 @@ def build_response(vcr_request, vcr_response, history):
     # cookies
     for hdr in response.headers.getall(hdrs.SET_COOKIE, ()):
         try:
-            response.cookies.load(hdr)
+            cookies = SimpleCookie(hdr)
+            for cookie_name, cookie in cookies.items():
+                expires = cookie.get('expires', '').strip()
+                if expires:
+                    log.debug("Ignoring expiration date: %s=\"%s\"", cookie_name, expires)
+                cookie['expires'] = ''
+                response.cookies.load(cookie.output(header='').strip())
         except CookieError as exc:
             log.warning("Can not load response cookies: %s", exc)
 

--- a/vcr/stubs/aiohttp_stubs.py
+++ b/vcr/stubs/aiohttp_stubs.py
@@ -134,7 +134,10 @@ def play_responses(cassette, vcr_request):
         # may have edge cases based on the headers we're providing (e.g. if
         # there's a matcher that is used to filter by headers).
         vcr_request = Request("GET", str(next_url), None, _serialize_headers(response.request_info.headers))
-        vcr_request = cassette.find_requests_with_most_matches(vcr_request)[0][0]
+        vcr_requests = cassette.find_requests_with_most_matches(vcr_request)
+        for vcr_request, *_ in vcr_requests:
+            if cassette.can_play_response_for(vcr_request):
+                break
 
         # Tack on the response we saw from the redirect into the history
         # list that is added on to the final response.

--- a/vcr/stubs/aiohttp_stubs.py
+++ b/vcr/stubs/aiohttp_stubs.py
@@ -77,11 +77,11 @@ def build_response(vcr_request, vcr_response, history):
         try:
             cookies = SimpleCookie(hdr)
             for cookie_name, cookie in cookies.items():
-                expires = cookie.get('expires', '').strip()
+                expires = cookie.get("expires", "").strip()
                 if expires:
-                    log.debug("Ignoring expiration date: %s=\"%s\"", cookie_name, expires)
-                cookie['expires'] = ''
-                response.cookies.load(cookie.output(header='').strip())
+                    log.debug('Ignoring expiration date: %s="%s"', cookie_name, expires)
+                cookie["expires"] = ""
+                response.cookies.load(cookie.output(header="").strip())
         except CookieError as exc:
             log.warning("Can not load response cookies: %s", exc)
 

--- a/vcr/stubs/aiohttp_stubs.py
+++ b/vcr/stubs/aiohttp_stubs.py
@@ -248,6 +248,8 @@ def vcr_request(cassette, real_request):
         if cassette.can_play_response_for(vcr_request):
             log.info("Playing response for {} from cassette".format(vcr_request))
             response = play_responses(cassette, vcr_request)
+            for redirect in response.history:
+                self._cookie_jar.update_cookies(redirect.cookies, redirect.url)
             self._cookie_jar.update_cookies(response.cookies, response.url)
             return response
 

--- a/vcr/stubs/aiohttp_stubs.py
+++ b/vcr/stubs/aiohttp_stubs.py
@@ -252,9 +252,7 @@ def vcr_request(cassette, real_request):
             return response
 
         if cassette.write_protected and cassette.filter_request(vcr_request):
-            raise CannotOverwriteExistingCassetteException(
-                cassette=cassette, failed_request=vcr_request
-            )
+            raise CannotOverwriteExistingCassetteException(cassette=cassette, failed_request=vcr_request)
 
         log.info("%s not in cassette, sending to real server", vcr_request)
 

--- a/vcr/stubs/aiohttp_stubs.py
+++ b/vcr/stubs/aiohttp_stubs.py
@@ -121,7 +121,7 @@ def play_responses(cassette, vcr_request):
         if "location" not in response.headers:
             break
 
-        next_url = URL(response.url).with_path(response.headers["location"])
+        next_url = URL(response.url).join(URL(response.headers["location"]))
 
         # Make a stub VCR request that we can then use to look up the recorded
         # VCR request saved to the cassette. This feels a little hacky and

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -242,7 +242,7 @@ def vcr_request(cassette, real_request):
         if cookie_header:
             headers[hdrs.COOKIE] = cookie_header
 
-        vcr_request = Request(method, str(request_url), data, headers)
+        vcr_request = Request(method, str(request_url), data, _serialize_headers(headers))
 
         if cassette.can_play_response_for(vcr_request):
             response = play_responses(cassette, vcr_request)

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -211,7 +211,11 @@ def vcr_request(cassette, real_request):
         vcr_request = Request(method, str(request_url), data, headers)
 
         if cassette.can_play_response_for(vcr_request):
-            return play_responses(cassette, vcr_request)
+            response = play_responses(cassette, vcr_request)
+            for resp in response.history:
+                self._cookie_jar.update_cookies(resp.cookies, resp.url)
+            self._cookie_jar.update_cookies(response.cookies, response.url)
+            return response
 
         if cassette.write_protected and cassette.filter_request(vcr_request):
             response = MockClientResponse(method, URL(url))

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -238,9 +238,7 @@ def vcr_request(cassette, real_request):
             request_url = URL(url).with_query(params)
 
         c_header = headers.pop(hdrs.COOKIE, None)
-        cookie_header = _build_cookie_header(
-            self, cookies, c_header, request_url
-        )
+        cookie_header = _build_cookie_header(self, cookies, c_header, request_url)
         if cookie_header:
             headers[hdrs.COOKIE] = cookie_header
 

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -11,6 +11,7 @@ from aiohttp.helpers import strip_auth_from_url
 from multidict import CIMultiDict, CIMultiDictProxy
 from yarl import URL
 
+from vcr.errors import CannotOverwriteExistingCassetteException
 from vcr.request import Request
 
 log = logging.getLogger(__name__)
@@ -245,21 +246,15 @@ def vcr_request(cassette, real_request):
         vcr_request = Request(method, str(request_url), data, _serialize_headers(headers))
 
         if cassette.can_play_response_for(vcr_request):
+            log.info("Playing response for {} from cassette".format(vcr_request))
             response = play_responses(cassette, vcr_request)
             self._cookie_jar.update_cookies(response.cookies, response.url)
             return response
 
         if cassette.write_protected and cassette.filter_request(vcr_request):
-            response = MockClientResponse(method, URL(url))
-            response.status = 599
-            msg = (
-                "No match for the request {!r} was found. Can't overwrite "
-                "existing cassette {!r} in your current record mode {!r}."
+            raise CannotOverwriteExistingCassetteException(
+                cassette=cassette, failed_request=vcr_request
             )
-            msg = msg.format(vcr_request, cassette._path, cassette.record_mode)
-            response._body = msg.encode()
-            response.close()
-            return response
 
         log.info("%s not in cassette, sending to real server", vcr_request)
 

--- a/vcr/stubs/aiohttp_stubs/__init__.py
+++ b/vcr/stubs/aiohttp_stubs/__init__.py
@@ -76,7 +76,7 @@ def build_response(vcr_request, vcr_response, history):
         try:
             response.cookies.load(hdr)
         except CookieError as exc:
-            log.warning('Can not load response cookies: %s', exc)
+            log.warning("Can not load response cookies: %s", exc)
 
     response.close()
     return response


### PR DESCRIPTION
This PR also partially solves #463. Each header is serialized as a list of strings but it can also deserialize from string for backwards compatibility.