### PR TITLE
aiohttp: Add support to allow_redirects option

### DIFF
--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -399,3 +399,19 @@ def test_cookies_redirect(scheme, tmpdir):
                 assert cookies["Cookie_1"].value == "Val_1"
 
     run_in_loop(run)
+
+
+def test_not_allow_redirects(tmpdir):
+    url = "https://mockbin.org/redirect/308/5"
+    path = str(tmpdir.join("redirects.yaml"))
+
+    with vcr.use_cassette(path):
+        response, _ = get(url, allow_redirects=False)
+        assert response.url.path == "/redirect/308/5"
+        assert response.status == 308
+
+    with vcr.use_cassette(path) as cassette:
+        response, _ = get(url, allow_redirects=False)
+        assert response.url.path == "/redirect/308/5"
+        assert response.status == 308
+        assert cassette.play_count == 1


### PR DESCRIPTION
Adds support to the `allow_redirects` options, which defaults to `True`, but in many cases we want to handle redirects manually:
> allow_redirects ([bool](https://docs.python.org/3/library/functions.html#bool)) – If set to False, do not follow redirects. True by default (optional).

https://docs.aiohttp.org/en/stable/client_reference.html