### PR TITLE
Added assertion message for only the new request

### DIFF
--- a/vcr/matchers.py
+++ b/vcr/matchers.py
@@ -45,7 +45,8 @@ def body(r1, r2):
     r2_transformer = _get_transformer(r2)
     if transformer != r2_transformer:
         transformer = _identity
-    assert transformer(read_body(r1)) == transformer(read_body(r2))
+    assert transformer(read_body(r1)) == transformer(read_body(r2)), \
+           "No stored requests match: {}".format(transformer(read_body(r1)))
 
 
 def headers(r1, r2):


### PR DESCRIPTION
I'd like to have something displayed as an error message when the body fails to match. Just having the request alone is beneficial enough for me (in case there might be issues with showing both requests).