### PR TITLE
Fix for the issue filter_post_data_parameters not working with aiohttp #398

### DIFF
--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -153,6 +153,19 @@ def test_replace_post_data_parameters_empty_body():
     assert request.body is None
 
 
+def test_replace_post_data_parameters_with_body_type_as_dict():
+    body = {'client_id': "123", "client_secret": "456"}
+    request = Request("POST", "http://google.com", body, {})
+    replace_post_data_parameters(
+        request,
+        [
+            ("client_id", "test_client_id"),
+            ("client_secret", "test_client_session")
+        ],
+    )
+    assert request.body == {'client_id': 'test_client_id', 'client_secret': 'test_client_session'}
+
+
 def test_remove_post_data_parameters():
     # Test the backward-compatible API wrapper.
     body = b"id=secret&foo=bar"

--- a/vcr/filters.py
+++ b/vcr/filters.py
@@ -94,6 +94,8 @@ def replace_post_data_parameters(request, replacements):
                     if rv is not None:
                         json_data[k] = rv
             request.body = json.dumps(json_data).encode("utf-8")
+        elif isinstance(request.body, dict):
+            request.body = replacements
         else:
             if isinstance(request.body, str):
                 request.body = request.body.encode("utf-8")


### PR DESCRIPTION
A test_replace_post_data_parameters_with_body_type_as_dict is added under /vcrpy/tests/unit/test_filters.py 