### PR TITLE
Changed how json is retrieved from kwargs, updated tests [aiohttp]

### DIFF
--- a/tests/integration/aiohttp_utils.py
+++ b/tests/integration/aiohttp_utils.py
@@ -7,7 +7,7 @@ from aiohttp.test_utils import TestClient
 
 async def aiohttp_request(loop, method, url, output="text", encoding="utf-8", content_type=None, **kwargs):
     session = aiohttp.ClientSession(loop=loop)
-    response_ctx = session.request(method, url, **kwargs)
+    response_ctx = getattr(session, method.lower())(url, **kwargs)
 
     response = await response_ctx.__aenter__()
     if output == "text":

--- a/vcr/stubs/aiohttp_stubs.py
+++ b/vcr/stubs/aiohttp_stubs.py
@@ -234,7 +234,7 @@ def vcr_request(cassette, real_request):
         headers = kwargs.get("headers")
         auth = kwargs.get("auth")
         headers = self._prepare_headers(headers)
-        data = kwargs.get("data", kwargs.get("json"))
+        data = kwargs.get("data") or kwargs.get("json")
         params = kwargs.get("params")
         cookies = kwargs.get("cookies")
 


### PR DESCRIPTION
This PR fixes https://github.com/kevin1024/vcrpy/issues/507

Current implementation works only when we send requests using `session.request("POST", url, json={'a': 1})`.
When `session.post(url, **kwargs)` is used, `kwargs` will look like this:
```python
{'data': None, 'json': {'a': 1}}
```
When using `session.post`/`session.put`/`session.put`, `'data'` will always be present in `kwargs` ([source](  https://github.com/aio-libs/aiohttp/blob/2aea4c0af30dc3c0047ae9a562ac87100f91e171/aiohttp/client.py#L902))

This is where `data = kwargs.get("data", kwargs.get("json"))` retrieves `None` value and why request body ends up to be empty in saved cassette.

I also updated tests to cover this issue.