### PR TITLE
Fix not working for binary response in httpx

### DIFF
--- a/tests/integration/test_httpx.py
+++ b/tests/integration/test_httpx.py
@@ -253,3 +253,14 @@ def test_redirect_wo_allow_redirects(do_request, yml):
         assert response.status_code == 308
 
         assert cassette.play_count == 1
+
+
+def test_binary(tmpdir, scheme, do_request):
+    url = scheme + "://httpbin.org/image/png"
+    with vcr.use_cassette(str(tmpdir.join("binary.yaml"))):
+        response = do_request()("GET", url)
+
+    with vcr.use_cassette(str(tmpdir.join("binary.yaml"))) as cassette:
+        cassette_response = do_request()("GET", url)
+        assert cassette_response.content == response.content
+        assert cassette.play_count == 1


### PR DESCRIPTION
The `httpx_reponse.content.decode("utf-8", "ignore")` would corrupt binary content that can't decoded to unicode. We should serialize the binary content directly in that case.

A better way to fix this is probably is set the content to `response["body"]["string"]` because `vcr.serializers.compat.convert_to_unicode()` and `vcr.serializers.compat.convert_to_bytes()` handle the bytes / unicode conversion of that field. But that will change the cassette format for httpx. I guess you guys can consider that when implementing #463. 