### PR TITLE
fix(aiohttp): record body of first request in redirect chain

### DIFF
--- a/vcr/stubs/aiohttp_stubs.py
+++ b/vcr/stubs/aiohttp_stubs.py
@@ -175,14 +175,14 @@ async def record_responses(cassette, vcr_request, response):
     to the final destination.
     """
 
-    for past_response in response.history:
+    for i, past_response in enumerate(response.history):
         aiohttp_request = past_response.request_info
 
-        # No data because it's following a redirect.
         past_request = Request(
             aiohttp_request.method,
             str(aiohttp_request.url),
-            None,
+            # Record body of first request, rest are following a redirect.
+            None if i else vcr_request.body,
             _serialize_headers(aiohttp_request.headers),
         )
         await record_response(cassette, past_request, past_response)


### PR DESCRIPTION
The first could be e.g. a POST with one, only the remaining ones are
expected to be GETs without one.