### PR TITLE
enables sending non-ascii characters in httpx requests

### DIFF
--- a/tests/integration/test_httpx.py
+++ b/tests/integration/test_httpx.py
@@ -99,6 +99,18 @@ def test_json(tmpdir, scheme, do_request):
         assert cassette.play_count == 1
 
 
+def test_post_binary_non_ascii_content(tmpdir, scheme, do_request):
+    url = scheme + "://httpbin.org/post"
+    with vcr.use_cassette(str(tmpdir.join("cointent.yaml"))):
+        binary_data = b"\xff\xd8\xff\xe0\x00\x10"
+        response = do_request()("POST", url, files={"some-image": binary_data})
+
+    with vcr.use_cassette(str(tmpdir.join("cointent.yaml"))) as cassette:
+        cassette_response = do_request()("POST", url, files={"some-image": binary_data})
+        assert cassette_response.content == response.content
+        assert cassette.play_count == 1
+
+
 def test_params_same_url_distinct_params(tmpdir, scheme, do_request):
     url = scheme + "://httpbin.org/get"
     headers = {"Content-Type": "application/json"}

--- a/vcr/stubs/httpx_stubs.py
+++ b/vcr/stubs/httpx_stubs.py
@@ -61,7 +61,7 @@ def _from_serialized_response(request, serialized_response, history=None):
 
 
 def _make_vcr_request(httpx_request, **kwargs):
-    body = httpx_request.read().decode("utf-8")
+    body = httpx_request.read()
     uri = str(httpx_request.url)
     headers = dict(httpx_request.headers)
     return VcrRequest(httpx_request.method, uri, body, headers)


### PR DESCRIPTION
The decode("utf-8") call in _make_vcr_request causes the request preparation to fail when non-ascii data is present in the binary.

Since The `vcr.request.Request` object is capable of checking if the body has a `read()` method and treat it according to since `7caf2973`, we can remove this call