### PR TITLE
Fix compressed response from httpx

### DIFF
--- a/vcr/stubs/httpx_stubs.py
+++ b/vcr/stubs/httpx_stubs.py
@@ -19,8 +19,12 @@ def _transform_headers(httpx_reponse):
     out = {}
     for key, var in httpx_reponse.headers.raw:
         decoded_key = key.decode("utf-8")
+        decoded_var = var.decode("utf-8")
+        # response already body decompresed by httpx, no need decompression in vcr filter
+        if decoded_key.lower() == "content-encoding" and decoded_var in ("gzip", "deflate"):
+            continue
         out.setdefault(decoded_key, [])
-        out[decoded_key].append(var.decode("utf-8"))
+        out[decoded_key].append(decoded_var)
     return out
 
 


### PR DESCRIPTION
In case of httpx responce.body decompressed automatically by httpx. If we not remove "content-encoding" header here, vcr.filters.decode_response will try to decompress already decompressed body.