### PR TITLE
Add the `alter_live_response` option

### DIFF
--- a/vcr/cassette.py
+++ b/vcr/cassette.py
@@ -180,6 +180,7 @@ class Cassette:
         match_on=(uri, method),
         before_record_request=None,
         before_record_response=None,
+        alter_live_response=False,
         custom_patches=(),
         inject=False,
         allow_playback_repeats=False,
@@ -191,6 +192,7 @@ class Cassette:
         self._before_record_request = before_record_request or (lambda x: x)
         log.info(self._before_record_request)
         self._before_record_response = before_record_response or (lambda x: x)
+        self._alter_live_response = alter_live_response
         self.inject = inject
         self.record_mode = record_mode
         self.custom_patches = custom_patches
@@ -229,10 +231,6 @@ class Cassette:
         request = self._before_record_request(request)
         if not request:
             return
-        # Deepcopy is here because mutation of `response` will corrupt the
-        # real response.
-        response = copy.deepcopy(response)
-        response = self._before_record_response(response)
         if response is None:
             return
         self.data.append((request, response))

--- a/vcr/config.py
+++ b/vcr/config.py
@@ -42,6 +42,7 @@ class VCR:
         ignore_localhost=False,
         filter_headers=(),
         before_record_response=None,
+        alter_live_response=None,
         filter_post_data_parameters=(),
         match_on=("method", "scheme", "host", "port", "path", "query"),
         before_record=None,
@@ -75,6 +76,7 @@ class VCR:
         self.filter_post_data_parameters = filter_post_data_parameters
         self.before_record_request = before_record_request or before_record
         self.before_record_response = before_record_response
+        self.alter_live_response = alter_live_response
         self.ignore_hosts = ignore_hosts
         self.ignore_localhost = ignore_localhost
         self.inject_cassette = inject_cassette
@@ -145,6 +147,7 @@ class VCR:
             "record_mode": kwargs.get("record_mode", self.record_mode),
             "before_record_request": self._build_before_record_request(kwargs),
             "before_record_response": self._build_before_record_response(kwargs),
+            "alter_live_response": self.alter_live_response,
             "custom_patches": self._custom_patches + kwargs.get("custom_patches", ()),
             "inject": kwargs.get("inject_cassette", self.inject_cassette),
             "path_transformer": path_transformer,


### PR DESCRIPTION
Fixes #544.

### The problem
Currently callbacks defined using the `before_record_response` can modify responses, but this creates an inconsistency where e.g. unit test cases see unmodified responses when cassettes are being recorded, and modified ones when they are later played back.

### The solution
The `alter_live_response = True` option instructs VCRpy to apply response modifications also to the live response when recording cassettes:
```python
def vcr_config():
    return {
        "before_record_response": [my_callback],
        "alter_live_response": True,
    }
```

This is an alternative to the `before_handle_response` option implemented in #594.

- [ ] unit tests
- [ ] documentation
- [ ] change log