### PR TITLE
Call urlparse less frequently

### DIFF
--- a/vcr/request.py
+++ b/vcr/request.py
@@ -24,6 +24,15 @@ class Request:
         log.debug("Invoking Request %s", self.uri)
 
     @property
+    def uri(self):
+        return self._uri
+
+    @uri.setter
+    def uri(self, uri):
+        self._uri = uri
+        self.parsed_uri = urlparse(uri)
+
+    @property
     def headers(self):
         return self._headers
 
@@ -52,30 +61,29 @@ class Request:
 
     @property
     def scheme(self):
-        return urlparse(self.uri).scheme
+        return self.parsed_uri.scheme
 
     @property
     def host(self):
-        return urlparse(self.uri).hostname
+        return self.parsed_uri.hostname
 
     @property
     def port(self):
-        parse_uri = urlparse(self.uri)
-        port = parse_uri.port
+        port = self.parsed_uri.port
         if port is None:
             try:
-                port = {"https": 443, "http": 80}[parse_uri.scheme]
+                port = {"https": 443, "http": 80}[self.parsed_uri.scheme]
             except KeyError:
                 pass
         return port
 
     @property
     def path(self):
-        return urlparse(self.uri).path
+        return self.parsed_uri.path
 
     @property
     def query(self):
-        q = urlparse(self.uri).query
+        q = self.parsed_uri.query
         return sorted(parse_qsl(q))
 
     # alias for backwards compatibility


### PR DESCRIPTION
Currently, `urlparse` is invoked for all properties of uri in `vcr.request.Request` which has an impact on performance especially with lengthy cassettes. I've changed this to use a property such that `urlparse` is only invoked when `uri` is changed.