### PR TITLE
Support the allow_redirects option of aiohttp when playing responses

### DIFF
--- a/vcr/stubs/aiohttp_stubs.py
+++ b/vcr/stubs/aiohttp_stubs.py
@@ -116,7 +116,7 @@ def _deserialize_headers(headers):
     return CIMultiDictProxy(deserialized_headers)
 
 
-def play_responses(cassette, vcr_request):
+def play_responses(cassette, vcr_request, allow_redirects):
     history = []
     vcr_response = cassette.play_response(vcr_request)
     response = build_response(vcr_request, vcr_response, history)
@@ -124,7 +124,7 @@ def play_responses(cassette, vcr_request):
     # If we're following redirects, continue playing until we reach
     # our final destination.
     while 300 <= response.status <= 399:
-        if "location" not in response.headers:
+        if "location" not in response.headers or allow_redirects is False:
             break
 
         next_url = URL(response.url).join(URL(response.headers["location"]))
@@ -237,6 +237,7 @@ def vcr_request(cassette, real_request):
         data = kwargs.get("data", kwargs.get("json"))
         params = kwargs.get("params")
         cookies = kwargs.get("cookies")
+        allow_redirects = kwargs.get("allow_redirects")
 
         if auth is not None:
             headers["AUTHORIZATION"] = auth.encode()
@@ -256,7 +257,7 @@ def vcr_request(cassette, real_request):
 
         if cassette.can_play_response_for(vcr_request):
             log.info("Playing response for {} from cassette".format(vcr_request))
-            response = play_responses(cassette, vcr_request)
+            response = play_responses(cassette, vcr_request, allow_redirects)
             for redirect in response.history:
                 self._cookie_jar.update_cookies(redirect.cookies, redirect.url)
             self._cookie_jar.update_cookies(response.cookies, response.url)


### PR DESCRIPTION
This is https://github.com/kevin1024/vcrpy/issues/571
In aiohttp the request method takes an optional "allow_redirects" parameter which can be set to False to disable redirects.