### PR TITLE
Fix httpx support (select between allow_redirects/follow_redirects)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ commands =
 deps =
     Werkzeug==2.0.3
     pytest
-    pytest-httpbin
+    git+https://github.com/immerrr/pytest-httpbin@fix-redirect-location-scheme-for-secure-server
     pytest-cov
     PyYAML
     ipaddress

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
   lint,
   {py37,py38,py39,py310}-{requests,httplib2,urllib3,tornado4,boto3,aiohttp,httpx},
   {pypy3}-{requests,httplib2,urllib3,tornado4,boto3},
+  {py310}-httpx019,
   cov-report
 
 
@@ -87,6 +88,10 @@ deps =
     aiohttp: pytest-aiohttp
     httpx: httpx
     {py37,py38,py39,py310}-{httpx}: httpx
+    {py37,py38,py39,py310}-{httpx}: pytest-asyncio
+    httpx: httpx>0.19
+    # httpx==0.19 is the latest version that supports allow_redirects, newer versions use follow_redirects
+    httpx019: httpx==0.19
     {py37,py38,py39,py310}-{httpx}: pytest-asyncio
 depends =
   lint,{py37,py38,py39,py310,pypy3}-{requests,httplib2,urllib3,tornado4,boto3},{py37,py38,py39,py310}-{aiohttp},{py37,py38,py39,py310}-{httpx}: cov-clean


### PR DESCRIPTION
This PR should fix the incompatibility introduced by the recent `httpx` release, when `allow_redirects` param was replaced with `follow_redirects` and default was changed from `True` to `False`.