### PR TITLE
Mimic aiohttp behavior around query parameters

### DIFF
--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -152,12 +152,13 @@ def test_post(tmpdir, scheme, body, caplog):
 
 
 def test_params(tmpdir, scheme):
-    url = scheme + "://httpbin.org/get"
+    url = scheme + "://httpbin.org/get?d=d"
     headers = {"Content-Type": "application/json"}
     params = {"a": 1, "b": 2, "c": "c"}
 
     with vcr.use_cassette(str(tmpdir.join("get.yaml"))) as cassette:
         _, response_json = get(url, output="json", params=params, headers=headers)
+        assert response_json["args"] == {"a": "1", "b": "2", "c": "c", "d": "d"}
 
     with vcr.use_cassette(str(tmpdir.join("get.yaml"))) as cassette:
         _, cassette_response_json = get(url, output="json", params=params, headers=headers)

--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -154,7 +154,7 @@ def test_post(tmpdir, scheme, body, caplog):
 def test_params(tmpdir, scheme):
     url = scheme + "://httpbin.org/get"
     headers = {"Content-Type": "application/json"}
-    params = {"a": 1, "b": False, "c": "c"}
+    params = {"a": 1, "b": 2, "c": "c"}
 
     with vcr.use_cassette(str(tmpdir.join("get.yaml"))) as cassette:
         _, response_json = get(url, output="json", params=params, headers=headers)
@@ -168,7 +168,7 @@ def test_params(tmpdir, scheme):
 def test_params_same_url_distinct_params(tmpdir, scheme):
     url = scheme + "://httpbin.org/get"
     headers = {"Content-Type": "application/json"}
-    params = {"a": 1, "b": False, "c": "c"}
+    params = {"a": 1, "b": 2, "c": "c"}
 
     with vcr.use_cassette(str(tmpdir.join("get.yaml"))) as cassette:
         _, response_json = get(url, output="json", params=params, headers=headers)

--- a/vcr/stubs/aiohttp_stubs.py
+++ b/vcr/stubs/aiohttp_stubs.py
@@ -244,8 +244,6 @@ def vcr_request(cassette, real_request):
 
         request_url = URL(url)
         if params:
-            for k, v in params.items():
-                params[k] = str(v)
             request_url = URL(url).with_query(params)
 
         c_header = headers.pop(hdrs.COOKIE, None)


### PR DESCRIPTION
## What

This PR makes vcr-aiohttp behave like aiohttp regarding query parameters. The vcr client can now handle `Mapping` like objects as arguments to `params`.

Closes #306.

## Why 

I encountered the same problem described in #306. The vcr-aiohttp client was behaving differently than aiohttp.

For example, the following code works well

```python
async def test_aiohttp():
    async with aiohttp.ClientSession() as session:
        async with session.get('http://httpbin.org/get',
                               params=[("a", 1), ("b", "b")]) as resp:
            assert "httpbin" in str(resp.url)
```

But it fails with vcrpy

```
   File "/$HOME/.local/lib/python3.7/site-packages/vcr/stubs/aiohttp_stubs.py", line 247, in new_request
    for k, v in params.items():
AttributeError: 'list' object has no attribute 'items'
```

## How

I practically copied and pasted aiohttp's source code that builds URLs with query parameters.

https://github.com/aio-libs/aiohttp/blob/master/aiohttp/client_reqrep.py#L225

I also removed the conversion of the parameter values into string since aiohttp doesn't do it. aiohttp fails if we give it a boolean, for example.

## Testing

I tested with Tox for Python 3.8 only.