### PR TITLE
fix: docs wording from request to response

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -271,7 +271,7 @@ You can also do response filtering with the
 similar to the above ``before_record_request`` - you can
 mutate the response, or return ``None`` to avoid recording
 the request and response altogether. For example to hide
-sensitive data from the request body:
+sensitive data from the response body:
 
 .. code:: python
 


### PR DESCRIPTION
I found a small typo under the `Custom Response Filtering` section where `response` was used instead of `request` which was a bit confusing. Corrected the wording to match the section it's talking about and the example following it.