### PR TITLE
Add support for matching request body multipart form data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 import re
 import sys
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 from setuptools.command.test import test as TestCommand
 
 long_description = open("README.rst", "r").read()
@@ -47,6 +47,7 @@ install_requires = [
     "wrapt",
     "six>=1.5",
     "yarl",
+    "requests_toolbelt",
 ]
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -79,6 +79,7 @@ deps =
     PyYAML
     ipaddress
     requests: requests>=2.22.0
+    requests_toolbelt
     httplib2: httplib2
     urllib3: urllib3
     boto3: boto3


### PR DESCRIPTION
Request bodies of content type `multipart/form-data` can have arbitrary "boundary" separators, but contain identical data. This can cause VCRPy's "body" matcher to fail on otherwise identical requests.

This adds support for parsing the encoded body data, essentially stripping out the "boundary" values, and comparing the contents.