### PR TITLE
Make httpx_stubs generate cassettes consistent with other stubs.

### DIFF
--- a/tests/integration/cassettes/gzip_httpx_old_format.yaml
+++ b/tests/integration/cassettes/gzip_httpx_old_format.yaml
@@ -1,0 +1,41 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      host:
+      - httpbin.org
+      user-agent:
+      - python-httpx/0.23.0
+    method: GET
+    uri: https://httpbin.org/gzip
+  response:
+    content: "{\n  \"gzipped\": true, \n  \"headers\": {\n    \"Accept\": \"*/*\",
+      \n    \"Accept-Encoding\": \"gzip, deflate, br\", \n    \"Host\": \"httpbin.org\",
+      \n    \"User-Agent\": \"python-httpx/0.23.0\", \n    \"X-Amzn-Trace-Id\": \"Root=1-62a62a8d-5f39b5c50c744da821d6ea99\"\n
+      \ }, \n  \"method\": \"GET\", \n  \"origin\": \"146.200.25.115\"\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '230'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 12 Jun 2022 18:03:57 GMT
+      Server:
+      - gunicorn/19.9.0
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/integration/cassettes/gzip_requests.yaml
+++ b/tests/integration/cassettes/gzip_requests.yaml
@@ -1,0 +1,42 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.0
+    method: GET
+    uri: https://httpbin.org/gzip
+  response:
+    body:
+      string: !!binary |
+        H4sIAKwrpmIA/z2OSwrCMBCG956izLIkfQSxkl2RogfQA9R2bIM1iUkqaOndnYDIrGa+/zELDB9l
+        LfYgg5uRwYhtj86DXKDuOrQBJKR5Cuy38kZ3pld6oHu0sqTH29QGZMnVkepgtMYuKKNJcEe0vJ3U
+        C4mcjI9hpaiygqaUW7ETFYGLR8frAXXE9h1Go7nD54w++FxkYp8VsDJ4IBH6E47NmVzGqUHFkn8g
+        rJsvp2omYs8AAAA=
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - Close
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '182'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 12 Jun 2022 18:08:44 GMT
+      Server:
+      - Pytest-HTTPBIN/0.1.0
+    status:
+      code: 200
+      message: great
+version: 1

--- a/tests/integration/test_httpx.py
+++ b/tests/integration/test_httpx.py
@@ -314,30 +314,3 @@ def test_load_gzipped(do_request, cassette_name, reason):
         assert cassette_response.status_code == 200
         assert cassette_response.reason_phrase == reason
 
-
-@pytest.mark.online
-def test_text_content_type(tmpdir, httpbin, do_request):
-    url = httpbin.url + "/json"
-
-    with vcr.use_cassette(str(tmpdir.join("json_type.yaml"))):
-        response = do_request()("GET", url)
-
-    with vcr.use_cassette(str(tmpdir.join("json_type.yaml"))) as cassette:
-        cassette_response = do_request()("GET", url)
-        assert cassette_response.content == response.content
-        assert cassette.play_count == 1
-        assert isinstance(cassette.responses[0]["content"], str)
-
-
-@pytest.mark.online
-def test_binary_content_type(tmpdir, httpbin, do_request):
-    url = httpbin.url + "/bytes/1024"
-
-    with vcr.use_cassette(str(tmpdir.join("json_type.yaml"))):
-        response = do_request()("GET", url)
-
-    with vcr.use_cassette(str(tmpdir.join("json_type.yaml"))) as cassette:
-        cassette_response = do_request()("GET", url)
-        assert cassette_response.content == response.content
-        assert cassette.play_count == 1
-        assert isinstance(cassette.responses[0]["content"], bytes)

--- a/tests/integration/test_httpx.py
+++ b/tests/integration/test_httpx.py
@@ -1,11 +1,14 @@
-import pytest
 import os
+
+import pytest
+
 import vcr
+
+from ..assertions import assert_is_json_bytes
 
 asyncio = pytest.importorskip("asyncio")
 httpx = pytest.importorskip("httpx")
 
-from ..assertions import assert_is_json_bytes
 
 @pytest.fixture(params=["https", "http"])
 def scheme(request):


### PR DESCRIPTION
Encountered this myself, but this was reported in #550.

I had generated some cassettes with _httplib2_, and then wanted to use them for _httpx_ - but they were entirely incompatible. This pull request resolves that.

But the cassette structure defined by _httpx_stubs_ was incompatible with other parts of the code - like the code to decode compressed responses. As such, I've changed the code such that it uses a set of response fields which are consistent with elsewhere in the codebase.

I've kept compatibility with the custom format that _httpx_stubs_ was using, so these cassettes can still be read - but no longer generated.

This pull request also includes two cassettes using the custom and regular formats, to show they can both be processed. I've based them on gzipped content, as this tests one of the complexities around how httpx was being used compared to other libraries (it seems content can only be retrieved in its decoded form, rather than the raw content given).