### PR TITLE
docs: Fix a few typos

### DIFF
--- a/tests/integration/test_record_mode.py
+++ b/tests/integration/test_record_mode.py
@@ -57,7 +57,7 @@ def test_new_episodes_record_mode(tmpdir, httpbin):
         assert cass.all_played
 
         # in the "new_episodes" record mode, we can add more requests to
-        # a cassette without repurcussions.
+        # a cassette without repercussions.
         urlopen(httpbin.url + "/get").read()
 
         # one of the responses has been played
@@ -108,7 +108,7 @@ def test_all_record_mode(tmpdir, httpbin):
         urlopen(httpbin.url).read()
 
         # in the "all" record mode, we can add more requests to
-        # a cassette without repurcussions.
+        # a cassette without repercussions.
         urlopen(httpbin.url + "/get").read()
 
         # The cassette was never actually played, even though it existed.

--- a/tests/integration/test_stubs.py
+++ b/tests/integration/test_stubs.py
@@ -64,7 +64,7 @@ def test_original_decoded_response_is_not_modified(tmpdir, httpbin):
         inside = conn.getresponse()
 
         # Assert that we do not modify the original response while appending
-        # to the casssette.
+        # to the cassette.
         assert "gzip" == inside.headers["content-encoding"]
 
         # They should effectively be the same response.

--- a/vcr/stubs/__init__.py
+++ b/vcr/stubs/__init__.py
@@ -87,7 +87,7 @@ class VCRHTTPResponse(HTTPResponse):
     def closed(self):
         # in python3, I can't change the value of self.closed.  So I'
         # twiddling self._closed and using this property to shadow the real
-        # self.closed from the superclas
+        # self.closed from the superclass
         return self._closed
 
     def read(self, *args, **kwargs):


### PR DESCRIPTION
There are small typos in:
- tests/integration/test_record_mode.py
- tests/integration/test_stubs.py
- vcr/stubs/__init__.py

Fixes:
- Should read `repercussions` rather than `repurcussions`.
- Should read `superclass` rather than `superclas`.
- Should read `cassette` rather than `casssette`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md