### PR TITLE
Restore the pytest-httpbin package in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,7 @@ commands =
 deps =
     Werkzeug==2.0.3
     pytest
-    git+https://github.com/immerrr/pytest-httpbin@fix-redirect-location-scheme-for-secure-server
+    pytest-httpbin>=1.0.1
     pytest-cov
     PyYAML
     ipaddress


### PR DESCRIPTION
The branch with the fix for HTTPS redirects is included in v1.0.1

See https://github.com/kevin1024/pytest-httpbin/releases/tag/v1.0.1