### PR TITLE
Add `before_record_interaction`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,8 @@ For a full list of triaged issues, bugs and PRs and what release they are target
 
 All help in providing PRs to close out bug issues is appreciated. Even if that is providing a repo that fully replicates issues. We have very generous contributors that have added these to bug issues which meant another contributor picked up the bug and closed it out.
 
+-  4.3.0
+    - Add `before_record_interaction` (thanks @edthedev, @ddriddle, @mpitcel, @zdc217, @tzturner)
 -  4.2.1
     - Fix a bug where the first request in a redirect chain was not being recorded with aiohttp
     - Various typos and small fixes, thanks @jairhenrique, @timgates42

--- a/tests/integration/test_filter.py
+++ b/tests/integration/test_filter.py
@@ -96,6 +96,36 @@ def test_filter_callback(tmpdir, httpbin):
         assert len(cass) == 0
 
 
+def test_before_record_interaction(tmpdir, httpbin):
+    url = httpbin.url + "/get"
+    cass_file = str(tmpdir.join("basic_auth_filter1.yaml"))
+
+    def before_record_interaction_cb(request, response):
+        if request.path == "/get":
+            return
+        return request, response
+
+    my_vcr = vcr.VCR(before_record_interaction=before_record_interaction_cb)
+    with my_vcr.use_cassette(cass_file, filter_headers=["authorization"]) as cass:
+        urlopen(url)
+        assert len(cass) == 0
+
+
+def test_before_record_interaction_override(tmpdir, httpbin):
+    url = httpbin.url + "/get"
+    cass_file = str(tmpdir.join("basic_auth_filter2.yaml"))
+
+    def before_record_interaction_cb(request, response):
+        if request.path == "/get":
+            return
+        return request, response
+
+    my_vcr = vcr.VCR()
+    with my_vcr.use_cassette(cass_file, before_record_interaction=before_record_interaction_cb) as cass:
+        urlopen(url)
+        assert len(cass) == 0
+
+
 def test_decompress_gzip(tmpdir, httpbin):
     url = httpbin.url + "/gzip"
     request = Request(url, headers={"Accept-Encoding": ["gzip, deflate"]})

--- a/tests/unit/test_cassettes.py
+++ b/tests/unit/test_cassettes.py
@@ -183,6 +183,16 @@ def test_before_record_response():
     assert cassette.responses[0] == "mutated"
 
 
+def test_before_record_interaction():
+    before_record_interaction = mock.Mock(return_value=("mutated", "twice"))
+    cassette = Cassette("test", before_record_interaction=before_record_interaction)
+    cassette.append("req", "res")
+
+    before_record_interaction.assert_called_once_with("req", "res")
+    assert cassette.requests[0] == "mutated"
+    assert cassette.responses[0] == "twice"
+
+
 def assert_get_response_body_is(value):
     conn = httplib.HTTPConnection("www.python.org")
     conn.request("GET", "/index.html")

--- a/vcr/cassette.py
+++ b/vcr/cassette.py
@@ -194,6 +194,7 @@ class Cassette:
         match_on=(uri, method),
         before_record_request=None,
         before_record_response=None,
+        before_record_interaction=None,
         custom_patches=(),
         inject=False,
         allow_playback_repeats=False,
@@ -205,6 +206,7 @@ class Cassette:
         self._before_record_request = before_record_request or (lambda x: x)
         log.info(self._before_record_request)
         self._before_record_response = before_record_response or (lambda x: x)
+        self._before_record_interaction = before_record_interaction or (lambda x, y: (x, y))
         self.inject = inject
         self.record_mode = record_mode
         self.custom_patches = custom_patches
@@ -249,7 +251,10 @@ class Cassette:
         response = self._before_record_response(response)
         if response is None:
             return
-        self.data.append((request, response))
+        interaction = self._before_record_interaction(request, response)
+        if interaction is None:
+            return
+        self.data.append(interaction)
         self.dirty = True
 
     def filter_request(self, request):

--- a/vcr/config.py
+++ b/vcr/config.py
@@ -41,6 +41,7 @@ class VCR:
         ignore_localhost=False,
         filter_headers=(),
         before_record_response=None,
+        before_record_interaction=None,
         filter_post_data_parameters=(),
         match_on=("method", "scheme", "host", "port", "path", "query"),
         before_record=None,
@@ -75,6 +76,7 @@ class VCR:
         self.filter_post_data_parameters = filter_post_data_parameters
         self.before_record_request = before_record_request or before_record
         self.before_record_response = before_record_response
+        self.before_record_interaction = before_record_interaction
         self.ignore_hosts = ignore_hosts
         self.ignore_localhost = ignore_localhost
         self.inject_cassette = inject_cassette
@@ -126,6 +128,7 @@ class VCR:
         cassette_library_dir = kwargs.get("cassette_library_dir", self.cassette_library_dir)
         additional_matchers = kwargs.get("additional_matchers", ())
         record_on_exception = kwargs.get("record_on_exception", self.record_on_exception)
+        before_record_interaction = kwargs.get("before_record_interaction", self.before_record_interaction)
 
         if cassette_library_dir:
 
@@ -147,6 +150,7 @@ class VCR:
             "record_mode": kwargs.get("record_mode", self.record_mode),
             "before_record_request": self._build_before_record_request(kwargs),
             "before_record_response": self._build_before_record_response(kwargs),
+            "before_record_interaction": before_record_interaction,
             "custom_patches": self._custom_patches + kwargs.get("custom_patches", ()),
             "inject": kwargs.get("inject_cassette", self.inject_cassette),
             "path_transformer": path_transformer,


### PR DESCRIPTION
- allows modifying response based on request, and vice-versa
- helps filter sensitive information out of recorded responses

Closes #556 #527

Co-authored-by: Edward Delaporte (@edthedev)
Co-authored-by: David Riddle (@ddriddle)
Co-authored-by: Michelle Pitcel (@mpitcel)
Co-authored-by: Zach Carrington (@zdc217)