### PR TITLE
Allow for changing patcher builder class

### DIFF
--- a/vcr/cassette.py
+++ b/vcr/cassette.py
@@ -58,12 +58,13 @@ class CassetteContextDecorator:
     def __init__(self, cls, args_getter):
         self.cls = cls
         self._args_getter = args_getter
+        self._patcher_builder_cls = CassettePatcherBuilder
         self.__finish = None
         self.__cassette = None
 
     def _patch_generator(self, cassette):
         with contextlib.ExitStack() as exit_stack:
-            for patcher in CassettePatcherBuilder(cassette).build():
+            for patcher in self._patcher_builder_cls(cassette).build():
                 exit_stack.enter_context(patcher)
             log_format = "{action} context for cassette at {path}."
             log.debug(log_format.format(action="Entering", path=cassette._path))


### PR DESCRIPTION
I have a project that uses its own `CassettePatcherBuilder` class to record interactions of a different sort than vcrpy does. However, right now this requires [a bit of a hack](https://github.com/amosjyng/vcr-langchain/blob/df45d3f784f93144f1ba8ee9517f7b55de134218/vcr_langchain/cassette.py#L18) to get around the hardcoded usage of `CassettePatcherBuilder` in the `_patch_generator` function. This is not great for future forward compatibility since my project will not be up to date on any future changes to `_patch_generator`, such as the most recent one where the function no longer saves cassettes because that is handled by `__exit__` instead.

Would it be possible to make the `CassettePatcherBuilder` class more configurable?