### PR TITLE
For custom cassette persisters no longer catch ValueError

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -136,7 +136,7 @@ Create your own persistence class, see the example below:
 
 Your custom persister must implement both ``load_cassette`` and ``save_cassette``
 methods.  The ``load_cassette`` method must return a deserialized cassette or raise
-``ValueError`` if no cassette is found.
+``CassetteNotFoundError`` if no cassette is found.
 
 Once the persister class is defined, register with VCR like so...
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -136,7 +136,8 @@ Create your own persistence class, see the example below:
 
 Your custom persister must implement both ``load_cassette`` and ``save_cassette``
 methods.  The ``load_cassette`` method must return a deserialized cassette or raise
-``CassetteNotFoundError`` if no cassette is found.
+either ``CassetteNotFoundError`` if no cassette is found, or ``CassetteDecodeError``
+if the cassette cannot be successfully deserialized.
 
 Once the persister class is defined, register with VCR like so...
 

--- a/tests/integration/test_register_persister.py
+++ b/tests/integration/test_register_persister.py
@@ -5,9 +5,11 @@
 import os
 from urllib.request import urlopen
 
+import pytest
+
 # Internal imports
 import vcr
-from vcr.persisters.filesystem import FilesystemPersister
+from vcr.persisters.filesystem import CassetteDecodeError, CassetteNotFoundError, FilesystemPersister
 
 
 class CustomFilesystemPersister:
@@ -23,6 +25,19 @@ class CustomFilesystemPersister:
     def save_cassette(cassette_path, cassette_dict, serializer):
         cassette_path += ".test"
         FilesystemPersister.save_cassette(cassette_path, cassette_dict, serializer)
+
+
+class BadPersister(FilesystemPersister):
+    """A bad persister that raises different errors."""
+
+    @staticmethod
+    def load_cassette(cassette_path, serializer):
+        if "nonexistent" in cassette_path:
+            raise CassetteNotFoundError()
+        elif "encoding" in cassette_path:
+            raise CassetteDecodeError()
+        else:
+            raise ValueError("buggy persister")
 
 
 def test_save_cassette_with_custom_persister(tmpdir, httpbin):
@@ -53,3 +68,22 @@ def test_load_cassette_with_custom_persister(tmpdir, httpbin):
     with my_vcr.use_cassette(test_fixture, serializer="json"):
         response = urlopen(httpbin.url).read()
         assert b"difficult sometimes" in response
+
+
+def test_load_cassette_with_custom_persister(tmpdir, httpbin):
+    """
+    Ensure expected errors from persister are swallowed while unexpected ones
+    are passed up the stack.
+    """
+    my_vcr = vcr.VCR()
+    my_vcr.register_persister(BadPersister)
+
+    with my_vcr.use_cassette("bad/nonexistent") as cass:
+        assert len(cass) == 0
+
+    with my_vcr.use_cassette("bad/encoding") as cass:
+        assert len(cass) == 0
+
+    with pytest.raises(ValueError):
+        with my_vcr.use_cassette("bad/buggy") as cass:
+            pass

--- a/tests/integration/test_register_persister.py
+++ b/tests/integration/test_register_persister.py
@@ -70,10 +70,10 @@ def test_load_cassette_with_custom_persister(tmpdir, httpbin):
         assert b"difficult sometimes" in response
 
 
-def test_load_cassette_with_custom_persister(tmpdir, httpbin):
+def test_load_cassette_persister_exception_handling(tmpdir, httpbin):
     """
     Ensure expected errors from persister are swallowed while unexpected ones
-    are passed up the stack.
+    are passed up the call stack.
     """
     my_vcr = vcr.VCR()
     my_vcr.register_persister(BadPersister)

--- a/tests/unit/test_cassettes.py
+++ b/tests/unit/test_cassettes.py
@@ -34,12 +34,12 @@ def test_cassette_load_nonexistent():
     assert len(a_cassette) == 0
 
 
-def test_cassette_load_invalid_unicode(tmpdir):
-    a_file = tmpdir.join("invalid_unicode.yml")
+def test_cassette_load_invalid_encoding(tmpdir):
+    a_file = tmpdir.join("invalid_encoding.yml")
     with open(a_file, "wb") as fd:
         fd.write(b"\xda")
-    with pytest.raises(UnicodeDecodeError):
-        Cassette.load(path=a_file)
+    a_cassette = Cassette.load(path=str(a_file))
+    assert len(a_cassette) == 0
 
 
 def test_cassette_not_played():

--- a/tests/unit/test_cassettes.py
+++ b/tests/unit/test_cassettes.py
@@ -29,6 +29,19 @@ def test_cassette_load(tmpdir):
     assert len(a_cassette) == 1
 
 
+def test_cassette_load_nonexistent():
+    a_cassette = Cassette.load(path="something/nonexistent.yml")
+    assert len(a_cassette) == 0
+
+
+def test_cassette_load_invalid_unicode(tmpdir):
+    a_file = tmpdir.join("invalid_unicode.yml")
+    with open(a_file, "wb") as fd:
+        fd.write(b"\xda")
+    with pytest.raises(UnicodeDecodeError):
+        Cassette.load(path=a_file)
+
+
 def test_cassette_not_played():
     a = Cassette("test")
     assert not a.play_count

--- a/vcr/cassette.py
+++ b/vcr/cassette.py
@@ -11,7 +11,7 @@ from ._handle_coroutine import handle_coroutine
 from .errors import UnhandledHTTPRequestError
 from .matchers import get_matchers_results, method, requests_match, uri
 from .patch import CassettePatcherBuilder
-from .persisters.filesystem import FilesystemPersister
+from .persisters.filesystem import FilesystemPersister, ExpectedCassetteError
 from .record_mode import RecordMode
 from .serializers import yamlserializer
 from .util import partition_dict
@@ -352,7 +352,7 @@ class Cassette:
                 self.append(request, response)
             self.dirty = False
             self.rewound = True
-        except ValueError:
+        except ExpectedCassetteError:
             pass
 
     def __str__(self):

--- a/vcr/cassette.py
+++ b/vcr/cassette.py
@@ -11,7 +11,7 @@ from ._handle_coroutine import handle_coroutine
 from .errors import UnhandledHTTPRequestError
 from .matchers import get_matchers_results, method, requests_match, uri
 from .patch import CassettePatcherBuilder
-from .persisters.filesystem import FilesystemPersister, ExpectedCassetteError
+from .persisters.filesystem import CassetteDecodeError, CassetteNotFoundError, FilesystemPersister
 from .record_mode import RecordMode
 from .serializers import yamlserializer
 from .util import partition_dict
@@ -352,7 +352,7 @@ class Cassette:
                 self.append(request, response)
             self.dirty = False
             self.rewound = True
-        except ExpectedCassetteError:
+        except (CassetteDecodeError, CassetteNotFoundError):
             pass
 
     def __str__(self):

--- a/vcr/persisters/filesystem.py
+++ b/vcr/persisters/filesystem.py
@@ -22,7 +22,7 @@ class FilesystemPersister:
         try:
             with cassette_path.open() as f:
                 data = f.read()
-        except UnicodeEncodeError as err:
+        except UnicodeDecodeError as err:
             raise CassetteDecodeError("Can't read Cassette, Encoding is broken") from err
 
         return deserialize(data, serializer)

--- a/vcr/persisters/filesystem.py
+++ b/vcr/persisters/filesystem.py
@@ -5,7 +5,11 @@ from pathlib import Path
 from ..serialize import deserialize, serialize
 
 
-class ExpectedCassetteError(ValueError):
+class CassetteNotFoundError(FileNotFoundError):
+    pass
+
+
+class CassetteDecodeError(ValueError):
     pass
 
 
@@ -14,12 +18,12 @@ class FilesystemPersister:
     def load_cassette(cls, cassette_path, serializer):
         cassette_path = Path(cassette_path)  # if cassette path is already Path this is no operation
         if not cassette_path.is_file():
-            raise ExpectedCassetteError("Cassette not found.")
+            raise CassetteNotFoundError()
         try:
             with cassette_path.open() as f:
                 data = f.read()
         except UnicodeEncodeError as err:
-            raise ExpectedCassetteError("Can't read Cassette, Encoding is broken") from err
+            raise CassetteDecodeError("Can't read Cassette, Encoding is broken") from err
 
         return deserialize(data, serializer)
 

--- a/vcr/persisters/filesystem.py
+++ b/vcr/persisters/filesystem.py
@@ -5,17 +5,21 @@ from pathlib import Path
 from ..serialize import deserialize, serialize
 
 
+class ExpectedCassetteError(ValueError):
+    pass
+
+
 class FilesystemPersister:
     @classmethod
     def load_cassette(cls, cassette_path, serializer):
         cassette_path = Path(cassette_path)  # if cassette path is already Path this is no operation
         if not cassette_path.is_file():
-            raise ValueError("Cassette not found.")
+            raise ExpectedCassetteError("Cassette not found.")
         try:
             with cassette_path.open() as f:
                 data = f.read()
         except UnicodeEncodeError as err:
-            raise ValueError("Can't read Cassette, Encoding is broken") from err
+            raise ExpectedCassetteError("Can't read Cassette, Encoding is broken") from err
 
         return deserialize(data, serializer)
 


### PR DESCRIPTION
I had to spend some time digging before I realized that serialization/deserialization errors were being swallowed here