### PR TITLE
Fix filter_query_parameters for aiohttp

### DIFF
--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -417,3 +417,16 @@ def test_not_allow_redirects(tmpdir):
         assert response.url.path == "/redirect/308/5"
         assert response.status == 308
         assert cassette.play_count == 1
+
+
+def test_filter_querystring(tmpdir, httpbin):
+    url = httpbin.url + "/?secretkey=secretvalue"
+    cass_file = str(tmpdir.join("aiohttp_filter_qs.yaml"))
+    with vcr.use_cassette(cass_file, filter_query_parameters=["secretkey"]):
+        response, _ = get(url)
+    with vcr.use_cassette(cass_file, filter_query_parameters=["secretkey"]):
+        response, _ = get(url)
+        with open(cass_file) as cass_file:
+            cass = cass_file.read()
+            assert "secretkey" not in cass
+            assert "secretvalue" not in cass

--- a/tests/integration/test_filter.py
+++ b/tests/integration/test_filter.py
@@ -45,13 +45,16 @@ def test_filter_basic_auth(tmpdir, httpbin):
 
 
 def test_filter_querystring(tmpdir, httpbin):
-    url = httpbin.url + "/?foo=bar"
+    url = httpbin.url + "/?secretkey=secretvalue"
     cass_file = str(tmpdir.join("filter_qs.yaml"))
-    with vcr.use_cassette(cass_file, filter_query_parameters=["foo"]):
+    with vcr.use_cassette(cass_file, filter_query_parameters=["secretkey"]):
         urlopen(url)
-    with vcr.use_cassette(cass_file, filter_query_parameters=["foo"]) as cass:
+    with vcr.use_cassette(cass_file, filter_query_parameters=["secretkey"]):
         urlopen(url)
-        assert "foo" not in cass.requests[0].url
+        with open(cass_file) as cass_file:
+            cass = cass_file.read()
+            assert "secretkey" not in cass
+            assert "secretvalue" not in cass
 
 
 def test_filter_post_data(tmpdir, httpbin):

--- a/vcr/stubs/aiohttp_stubs.py
+++ b/vcr/stubs/aiohttp_stubs.py
@@ -66,7 +66,7 @@ def build_response(vcr_request, vcr_response, history):
         headers=_deserialize_headers(vcr_request.headers),
         real_url=URL(vcr_request.url),
     )
-    response = MockClientResponse(vcr_request.method, URL(vcr_response.get("url")), request_info=request_info)
+    response = MockClientResponse(vcr_request.method, URL(vcr_request.url), request_info=request_info)
     response.status = vcr_response["status"]["code"]
     response._body = vcr_response["body"].get("string", b"")
     response.reason = vcr_response["status"]["message"]
@@ -163,7 +163,6 @@ async def record_response(cassette, vcr_request, response):
         "status": {"code": response.status, "message": response.reason},
         "headers": _serialize_headers(response.headers),
         "body": body,  # NOQA: E999
-        "url": str(response.url),
     }
 
     cassette.append(vcr_request, vcr_response)


### PR DESCRIPTION
For some unknown reason, the aiohttp stub was recording the unfiltered *request* URL as part of the response in the cassette. Other stubs do not seem to do this and I found no other requirement for response.url to be present, therefore the easy fix was to remove it entirely.

Fixes #517.