### PR TITLE
Support both urllib3 v1 and v2 at the same time (fixes #688)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,13 @@ install_requires = [
     "wrapt",
     "six>=1.5",
     "yarl",
+    # Support for urllib3 >=2 needs Python >=3.10
+    # so we need to block urllib3 >=2 for Python <3.10 for now.
+    # Note that vcrpy would work fine without any urllib3 around,
+    # so this block and the dependency can be dropped at some point
+    # in the future. For more Details:
+    # https://github.com/kevin1024/vcrpy/pull/699#issuecomment-1551439663
+    "urllib3 <2; python_version <'3.10'",
 ]
 
 setup(

--- a/tests/integration/test_urllib3.py
+++ b/tests/integration/test_urllib3.py
@@ -8,6 +8,7 @@ from assertions import assert_cassette_empty, assert_is_json
 
 import vcr
 from vcr.patch import force_reset
+from vcr.stubs.compat import get_headers
 
 urllib3 = pytest.importorskip("urllib3")
 
@@ -41,7 +42,8 @@ def test_headers(tmpdir, httpbin_both, verify_pool_mgr):
         headers = verify_pool_mgr.request("GET", url).headers
 
     with vcr.use_cassette(str(tmpdir.join("headers.yaml"))):
-        assert headers == verify_pool_mgr.request("GET", url).headers
+        new_headers = verify_pool_mgr.request("GET", url).headers
+        assert sorted(get_headers(headers)) == sorted(get_headers(new_headers))
 
 
 def test_body(tmpdir, httpbin_both, verify_pool_mgr):

--- a/tests/integration/test_urllib3.py
+++ b/tests/integration/test_urllib3.py
@@ -145,18 +145,18 @@ def test_https_with_cert_validation_disabled(tmpdir, httpbin_secure, pool_mgr):
 
 
 def test_urllib3_force_reset():
-    cpool = urllib3.connectionpool
-    http_original = cpool.HTTPConnection
-    https_original = cpool.HTTPSConnection
-    verified_https_original = cpool.VerifiedHTTPSConnection
+    conn = urllib3.connection
+    http_original = conn.HTTPConnection
+    https_original = conn.HTTPSConnection
+    verified_https_original = conn.VerifiedHTTPSConnection
     with vcr.use_cassette(path="test"):
-        first_cassette_HTTPConnection = cpool.HTTPConnection
-        first_cassette_HTTPSConnection = cpool.HTTPSConnection
-        first_cassette_VerifiedHTTPSConnection = cpool.VerifiedHTTPSConnection
+        first_cassette_HTTPConnection = conn.HTTPConnection
+        first_cassette_HTTPSConnection = conn.HTTPSConnection
+        first_cassette_VerifiedHTTPSConnection = conn.VerifiedHTTPSConnection
         with force_reset():
-            assert cpool.HTTPConnection is http_original
-            assert cpool.HTTPSConnection is https_original
-            assert cpool.VerifiedHTTPSConnection is verified_https_original
-        assert cpool.HTTPConnection is first_cassette_HTTPConnection
-        assert cpool.HTTPSConnection is first_cassette_HTTPSConnection
-        assert cpool.VerifiedHTTPSConnection is first_cassette_VerifiedHTTPSConnection
+            assert conn.HTTPConnection is http_original
+            assert conn.HTTPSConnection is https_original
+            assert conn.VerifiedHTTPSConnection is verified_https_original
+        assert conn.HTTPConnection is first_cassette_HTTPConnection
+        assert conn.HTTPSConnection is first_cassette_HTTPSConnection
+        assert conn.VerifiedHTTPSConnection is first_cassette_VerifiedHTTPSConnection

--- a/tests/integration/test_wild.py
+++ b/tests/integration/test_wild.py
@@ -64,9 +64,10 @@ def test_cookies(tmpdir, httpbin):
     with vcr.use_cassette(testfile):
         s = requests.Session()
         s.get(httpbin.url + "/cookies/set?k1=v1&k2=v2")
+        assert s.cookies.keys() == ["k1", "k2"]
 
         r2 = s.get(httpbin.url + "/cookies")
-        assert len(r2.json()["cookies"]) == 2
+        assert sorted(r2.json()["cookies"].keys()) == ["k1", "k2"]
 
 
 def test_amazon_doctype(tmpdir):

--- a/tests/unit/test_vcr.py
+++ b/tests/unit/test_vcr.py
@@ -41,7 +41,7 @@ def test_vcr_use_cassette():
 
 
 def test_vcr_before_record_request_params():
-    base_path = "http://httpbin.org/"
+    base_path = "http://whatever.test/"
 
     def before_record_cb(request):
         if request.path != "/get":

--- a/tox.ini
+++ b/tox.ini
@@ -88,7 +88,6 @@ deps =
     httplib2: httplib2
     urllib3: urllib3
     boto3: boto3
-    boto3: urllib3
     aiohttp: aiohttp
     aiohttp: pytest-asyncio
     aiohttp: pytest-aiohttp

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,9 @@ skip_missing_interpreters=true
 envlist =
   cov-clean,
   lint,
-  {py37,py38,py39,py310,py311}-{requests-urllib3-1,requests-urllib3-2,httplib2,urllib3-1,urllib3-2,tornado4,boto3,aiohttp,httpx},
-  {pypy3}-{requests-urllib3-1,requests-urllib3-2,httplib2,urllib3-1,urllib3-2,tornado4,boto3},
+  {py37,py38,py39,py310,py311}-{requests-urllib3-1,httplib2,urllib3-1,tornado4,boto3,aiohttp,httpx},
+  {py310,py311}-{requests-urllib3-2,urllib3-2},
+  {pypy3}-{requests-urllib3-1,httplib2,urllib3-1,tornado4,boto3},
   {py310}-httpx019,
   cov-report
 
@@ -100,8 +101,8 @@ deps =
     httpx019: httpx==0.19
     {py37,py38,py39,py310}-{httpx}: pytest-asyncio
 depends =
-  lint,{py37,py38,py39,py310,py311,pypy3}-{requests-urllib3-1,requests-urllib3-2,httplib2,urllib3-1,urllib3-2,tornado4,boto3},{py37,py38,py39,py310,py311}-{aiohttp},{py37,py38,py39,py310,py311}-{httpx}: cov-clean
-  cov-report: lint,{py37,py38,py39,py310,py311,pypy3}-{requests-urllib3-1,requests-urllib3-2,httplib2,urllib3-1,urllib3-2,tornado4,boto3},{py37,py38,py39,py310,py311}-{aiohttp}
+  lint,{py37,py38,py39,py310,py311,pypy3}-{requests-urllib3-1,httplib2,urllib3-1,tornado4,boto3},{py310,py311}-{requests-urllib3-2,urllib3-2},{py37,py38,py39,py310,py311}-{aiohttp},{py37,py38,py39,py310,py311}-{httpx}: cov-clean
+  cov-report: lint,{py37,py38,py39,py310,py311,pypy3}-{requests-urllib3-1,httplib2,urllib3-1,tornado4,boto3},{py310,py311}-{requests-urllib3-2,urllib3-2},{py37,py38,py39,py310,py311}-{aiohttp}
 passenv =
     AWS_ACCESS_KEY_ID
     AWS_DEFAULT_REGION

--- a/tox.ini
+++ b/tox.ini
@@ -85,9 +85,8 @@ deps =
     PyYAML
     ipaddress
     requests: requests>=2.22.0
-    requests: urllib3<2
     httplib2: httplib2
-    urllib3: urllib3<2
+    urllib3: urllib3
     boto3: boto3
     boto3: urllib3
     aiohttp: aiohttp

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ skip_missing_interpreters=true
 envlist =
   cov-clean,
   lint,
-  {py37,py38,py39,py310,py311}-{requests,httplib2,urllib3,tornado4,boto3,aiohttp,httpx},
-  {pypy3}-{requests,httplib2,urllib3,tornado4,boto3},
+  {py37,py38,py39,py310,py311}-{requests-urllib3-1,requests-urllib3-2,httplib2,urllib3-1,urllib3-2,tornado4,boto3,aiohttp,httpx},
+  {pypy3}-{requests-urllib3-1,requests-urllib3-2,httplib2,urllib3-1,urllib3-2,tornado4,boto3},
   {py310}-httpx019,
   cov-report
 
@@ -86,7 +86,8 @@ deps =
     ipaddress
     requests: requests>=2.22.0
     httplib2: httplib2
-    urllib3: urllib3
+    urllib3-1: urllib3<2
+    urllib3-2: urllib3<3
     boto3: boto3
     aiohttp: aiohttp
     aiohttp: pytest-asyncio
@@ -99,8 +100,8 @@ deps =
     httpx019: httpx==0.19
     {py37,py38,py39,py310}-{httpx}: pytest-asyncio
 depends =
-  lint,{py37,py38,py39,py310,py311,pypy3}-{requests,httplib2,urllib3,tornado4,boto3},{py37,py38,py39,py310,py311}-{aiohttp},{py37,py38,py39,py310,py311}-{httpx}: cov-clean
-  cov-report: lint,{py37,py38,py39,py310,py311,pypy3}-{requests,httplib2,urllib3,tornado4,boto3},{py37,py38,py39,py310,py311}-{aiohttp}
+  lint,{py37,py38,py39,py310,py311,pypy3}-{requests-urllib3-1,requests-urllib3-2,httplib2,urllib3-1,urllib3-2,tornado4,boto3},{py37,py38,py39,py310,py311}-{aiohttp},{py37,py38,py39,py310,py311}-{httpx}: cov-clean
+  cov-report: lint,{py37,py38,py39,py310,py311,pypy3}-{requests-urllib3-1,requests-urllib3-2,httplib2,urllib3-1,urllib3-2,tornado4,boto3},{py37,py38,py39,py310,py311}-{aiohttp}
 passenv =
     AWS_ACCESS_KEY_ID
     AWS_DEFAULT_REGION

--- a/vcr/stubs/__init__.py
+++ b/vcr/stubs/__init__.py
@@ -249,12 +249,13 @@ class VCRConnection:
 
             # get the response
             response = self.real_connection.getresponse()
+            response_data = response.data if hasattr(response, "data") else response.read()
 
             # put the response into the cassette
             response = {
                 "status": {"code": response.status, "message": response.reason},
                 "headers": serialize_headers(response),
-                "body": {"string": response.read()},
+                "body": {"string": response_data},
             }
             self.cassette.append(self._vcr_request, response)
         return VCRHTTPResponse(response)

--- a/vcr/stubs/__init__.py
+++ b/vcr/stubs/__init__.py
@@ -144,6 +144,28 @@ class VCRHTTPResponse(HTTPResponse):
     def readable(self):
         return self._content.readable()
 
+    @property
+    def length_remaining(self):
+        return self._content.getbuffer().nbytes - self._content.tell()
+
+    def get_redirect_location(self):
+        """
+        Returns (a) redirect location string if we got a redirect
+        status code and valid location, (b) None if redirect status and
+        no location, (c) False if not a redirect status code.
+        See https://urllib3.readthedocs.io/en/stable/reference/urllib3.response.html .
+        """
+        if not (300 <= self.status <= 399):
+            return False
+        return self.getheader("Location")
+
+    @property
+    def data(self):
+        return self._content.getbuffer().tobytes()
+
+    def drain_conn(self):
+        pass
+
 
 class VCRConnection:
     # A reference to the cassette that's currently being patched in

--- a/vcr/stubs/__init__.py
+++ b/vcr/stubs/__init__.py
@@ -68,6 +68,7 @@ class VCRHTTPResponse(HTTPResponse):
         self.version = None
         self._content = BytesIO(self.recorded_response["body"]["string"])
         self._closed = False
+        self._original_response = self  # for requests.session.Session cookie extraction
 
         headers = self.recorded_response["headers"]
         # Since we are loading a response that has already been serialized, our

--- a/vcr/stubs/__init__.py
+++ b/vcr/stubs/__init__.py
@@ -47,8 +47,9 @@ def parse_headers(header_list):
 
 
 def serialize_headers(response):
+    headers = response.headers if response.msg is None else response.msg
     out = {}
-    for key, values in compat.get_headers(response.msg):
+    for key, values in compat.get_headers(headers):
         out.setdefault(key, [])
         out[key].extend(values)
     return out

--- a/vcr/stubs/requests_stubs.py
+++ b/vcr/stubs/requests_stubs.py
@@ -1,6 +1,6 @@
 """Stubs for requests"""
 
-from urllib3.connectionpool import HTTPConnection, VerifiedHTTPSConnection
+from urllib3.connection import HTTPConnection, VerifiedHTTPSConnection
 
 from ..stubs import VCRHTTPConnection, VCRHTTPSConnection
 

--- a/vcr/stubs/urllib3_stubs.py
+++ b/vcr/stubs/urllib3_stubs.py
@@ -1,6 +1,6 @@
 """Stubs for urllib3"""
 
-from urllib3.connectionpool import HTTPConnection, VerifiedHTTPSConnection
+from urllib3.connection import HTTPConnection, VerifiedHTTPSConnection
 
 from ..stubs import VCRHTTPConnection, VCRHTTPSConnection
 


### PR DESCRIPTION
Hi! :wave:

This builds on the work by @shifqu in #697 literally. Fixes #688, happy to adjust.

I would like to note two things:
- If anyone has ideas about the urllib3 v2 SSL connection abort protocol errors that seems to happen with Python 3.7/3.8/3.9 but not with Python 3.10/3.11 — that would rock! :pray: 
- If some form of this pull request ends up being merged, please do not squash the commits together. Thanks! :pray: 

Looking forward to your review! :beers: 

CC @jairhenrique @kevin1024 @pquentin @shifqu @vEpiphyte