### PR TITLE
GitHub Actions: Stop installing libgnutls28-dev

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,6 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.8"]
 
     steps:
-      - name: Install libgnutls28-dev
-        run: |
-          sudo apt update -q
-          sudo apt install -q -y libgnutls28-dev libcurl4-gnutls-dev
-
       - uses: actions/checkout@v3.5.2
 
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Does not seem to serve a purpose… drop?