### PR TITLE
Codespell: action + config

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,19 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,6 @@ include_trailing_comma = true
 
 [tool.codespell]
 skip = '.git,*.pdf,*.svg,.tox'
+ignore-regex = "\\\\[fnrstv]"
 #
 # ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,8 @@ known_first_party = "vcrpy"
 multi_line_output = 3
 use_parentheses = true
 include_trailing_comma = true
+
+[tool.codespell]
+skip = '.git,*.pdf,*.svg,.tox'
+#
+# ignore-words-list = ''


### PR DESCRIPTION
once in a while people have a chance to contribute to vcrpy simply by fixing typos, e.g. 44359bfe43fcabb151331723db5551053033d854 and e05ebca5e505077efdcff9f2f0ac901ec967411e . Evil me wants to preclude that and to prevent typos appearing to start with! This PR adds codespell config and github action for that evil purpose.