### PR TITLE
test_aiohttp.py: Make cookie tests use (local) pytest-httpbin to make them more robust

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,3 +1,6 @@
+import os
+import ssl
+
 import pytest
 
 
@@ -15,3 +18,15 @@ def mockbin(scheme):
 @pytest.fixture
 def mockbin_request_url(mockbin):
     return mockbin + "/request"
+
+
+@pytest.fixture
+def httpbin_ssl_context():
+    ssl_ca_location = os.environ["REQUESTS_CA_BUNDLE"]
+    ssl_cert_location = os.environ["REQUESTS_CA_BUNDLE"].replace("cacert.pem", "cert.pem")
+    ssl_key_location = os.environ["REQUESTS_CA_BUNDLE"].replace("cacert.pem", "key.pem")
+
+    ssl_context = ssl.create_default_context(cafile=ssl_ca_location)
+    ssl_context.load_cert_chain(ssl_cert_location, ssl_key_location)
+
+    return ssl_context


### PR DESCRIPTION
After https://github.com/kevin1024/vcrpy/actions/runs/5080550552 took 10(!) retries today to become fully green, let's get the flakiness out of `test_aiohttp.py` finally…