### PR TITLE
VCRHTTPResponse Not Working with Biopython 1.81

### DIFF
--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -93,7 +93,7 @@ def test_response_parses_correctly_and_fp_attribute_error_is_not_thrown():
         },
     }
     vcr_response = VCRHTTPResponse(recorded_response)
-    handle = io.TextIOWrapper(io.BufferedReader(vcr_response), encoding="utf-8")
+    handle = io.TextIOWrapper(vcr_response, encoding="utf-8")
     handle = iter(handle)
     articles = [line for line in handle]
     assert len(articles) > 1

--- a/vcr/stubs/__init__.py
+++ b/vcr/stubs/__init__.py
@@ -93,6 +93,9 @@ class VCRHTTPResponse(HTTPResponse):
     def read(self, *args, **kwargs):
         return self._content.read(*args, **kwargs)
 
+    def read1(self, *args, **kwargs):
+        return self._content.read1(*args, **kwargs)
+
     def readall(self):
         return self._content.readall()
 


### PR DESCRIPTION
I am using Python 3.11, `biopython==1.81`, and `vcrpy==4.3.1`

Newer versions of biopython perform:

```python
handle = io.TextIOWrapper(vcr_response, encoding="utf-8")
```

rather than

```python
handle = io.TextIOWrapper(io.BufferedReader(vcr_response), encoding="utf-8")
```

When iterating over this object, there were no items (but calling this outside of VCR there were). It turned out all that was needed to fix this issue was to implement the `read1` method on `VCRHTTPResponse`.
