### PR TITLE
Fix docs/usage.rst code examples

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -4,7 +4,7 @@ Usage
 .. code:: python
 
     import vcr
-    import urllib
+    import urllib.request
 
     with vcr.use_cassette('fixtures/vcr_cassettes/synopsis.yaml'):
         response = urllib.request.urlopen('http://www.iana.org/domains/reserved').read()

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -8,7 +8,7 @@ Usage
 
     with vcr.use_cassette('fixtures/vcr_cassettes/synopsis.yaml'):
         response = urllib.request.urlopen('http://www.iana.org/domains/reserved').read()
-        assert 'Example domains' in response
+        assert b'Example domains' in response
 
 Run this test once, and VCR.py will record the HTTP request to
 ``fixtures/vcr_cassettes/synopsis.yaml``. Run it again, and VCR.py will
@@ -26,7 +26,7 @@ look like this:
     @vcr.use_cassette('fixtures/vcr_cassettes/synopsis.yaml')
     def test_iana():
         response = urllib.request.urlopen('http://www.iana.org/domains/reserved').read()
-        assert 'Example domains' in response
+        assert b'Example domains' in response
 
 When using the decorator version of ``use_cassette``, it is possible to
 omit the path to the cassette file.
@@ -36,7 +36,7 @@ omit the path to the cassette file.
     @vcr.use_cassette()
     def test_iana():
         response = urllib.request.urlopen('http://www.iana.org/domains/reserved').read()
-        assert 'Example domains' in response
+        assert b'Example domains' in response
 
 In this case, the cassette file will be given the same name as the test
 function, and it will be placed in the same directory as the file in


### PR DESCRIPTION
Hi! :wave: 

When running the example from…

https://github.com/kevin1024/vcrpy/blob/e3aae34ef7bf45f01ebff19fe72757c30a847735/docs/usage.rst?plain=1#L6-L11

…I get two errors:

The first is:

```
Traceback (most recent call last):
  File "/tmp/tmp.kJAKlLngAX/foo.py", line 5, in <module>
    response = urllib.request.urlopen('http://www.iana.org/domains/reserved').read()
AttributeError: module 'urllib' has no attribute 'request'
```

After fixing the import, the second is:

```
Traceback (most recent call last):
  File "/tmp/tmp.kJAKlLngAX/foo.py", line 6, in <module>
    assert 'Example domains' in response
TypeError: a bytes-like object is required, not 'str'
```

This pull request fixes both of these issues.