### PR TITLE
Make CI enforce that all online tests are marked with @pytest.mark.online

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,5 +31,13 @@ jobs:
       - name: Run tests with tox
         run: tox
 
+      - name: Run offline tests with tox with no access to the Internet
+        run: |
+          # We're using unshare to take Internet access
+          # away from tox so that we'll notice whenever some new test
+          # is missing @pytest.mark.online decoration in the future
+          unshare --map-root-user --net -- \
+              sh -c 'ip link set lo up; tox -- -m "not online"'
+
       - name: Run coverage
         run: codecov

--- a/runtests.sh
+++ b/runtests.sh
@@ -4,4 +4,4 @@
 # If you are getting an INVOCATION ERROR for this script then there is 
 # a good chance you are running on Windows.
 # You can and should use WSL for running tox on Windows when it calls bash scripts.
-REQUESTS_CA_BUNDLE=`python -m pytest_httpbin.certs` pytest $*
+REQUESTS_CA_BUNDLE=`python -m pytest_httpbin.certs` exec pytest "$@"


### PR DESCRIPTION
Follow-up to #674

This will make sure that distributors like Debian and Gentoo can run tests with `-m 'not online'` without worry that there are  tests accessing the Internet that are just missing `@pytest.mark.online` decoration…

CC @jspricke @jairhenrique