### PR TITLE
assertions.py: Fix mis-leading `assert_is_json`

### DIFF
--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -11,9 +11,10 @@ def assert_cassette_has_one_response(cass):
     assert cass.play_count == 1
 
 
-def assert_is_json(a_string):
+def assert_is_json_bytes(b: bytes):
+    assert isinstance(b, bytes)
     try:
-        json.loads(a_string.decode("utf-8"))
+        json.loads(b.decode("utf-8"))
     except Exception:
         assert False
     assert True

--- a/tests/integration/test_filter.py
+++ b/tests/integration/test_filter.py
@@ -5,7 +5,7 @@ from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 import pytest
-from assertions import assert_cassette_has_one_response, assert_is_json
+from assertions import assert_cassette_has_one_response, assert_is_json_bytes
 
 import vcr
 
@@ -105,7 +105,7 @@ def test_decompress_gzip(tmpdir, httpbin):
     with vcr.use_cassette(cass_file) as cass:
         decoded_response = urlopen(url).read()
         assert_cassette_has_one_response(cass)
-    assert_is_json(decoded_response)
+    assert_is_json_bytes(decoded_response)
 
 
 def test_decomptess_empty_body(tmpdir, httpbin):
@@ -129,7 +129,7 @@ def test_decompress_deflate(tmpdir, httpbin):
     with vcr.use_cassette(cass_file) as cass:
         decoded_response = urlopen(url).read()
         assert_cassette_has_one_response(cass)
-    assert_is_json(decoded_response)
+    assert_is_json_bytes(decoded_response)
 
 
 def test_decompress_regular(tmpdir, httpbin):
@@ -141,7 +141,7 @@ def test_decompress_regular(tmpdir, httpbin):
     with vcr.use_cassette(cass_file) as cass:
         resp = urlopen(url).read()
         assert_cassette_has_one_response(cass)
-    assert_is_json(resp)
+    assert_is_json_bytes(resp)
 
 
 def test_before_record_request_corruption(tmpdir, httpbin):

--- a/tests/integration/test_requests.py
+++ b/tests/integration/test_requests.py
@@ -1,6 +1,6 @@
 """Test requests' interaction with vcr"""
 import pytest
-from assertions import assert_cassette_empty, assert_is_json
+from assertions import assert_cassette_empty, assert_is_json_bytes
 
 import vcr
 
@@ -176,7 +176,7 @@ def test_gzip__decode_compressed_response_false(tmpdir, httpbin_both):
         with vcr.use_cassette(str(tmpdir.join("gzip.yaml"))):
             response = requests.get(httpbin_both + "/gzip")
             assert response.headers["content-encoding"] == "gzip"  # i.e. not removed
-            assert_is_json(response.content)  # i.e. uncompressed bytes
+            assert_is_json_bytes(response.content)  # i.e. uncompressed bytes
 
 
 def test_gzip__decode_compressed_response_true(tmpdir, httpbin_both):

--- a/tests/integration/test_stubs.py
+++ b/tests/integration/test_stubs.py
@@ -2,7 +2,7 @@ import http.client as httplib
 import json
 import zlib
 
-from assertions import assert_is_json
+from assertions import assert_is_json_bytes
 
 import vcr
 
@@ -84,7 +84,7 @@ def test_original_decoded_response_is_not_modified(tmpdir, httpbin):
         inside = conn.getresponse()
 
         assert "content-encoding" not in inside.headers
-        assert_is_json(inside.read())
+        assert_is_json_bytes(inside.read())
 
 
 def _make_before_record_response(fields, replacement="[REDACTED]"):

--- a/tests/integration/test_tornado.py
+++ b/tests/integration/test_tornado.py
@@ -4,7 +4,7 @@
 import json
 
 import pytest
-from assertions import assert_cassette_empty, assert_is_json
+from assertions import assert_cassette_empty, assert_is_json_bytes
 
 import vcr
 from vcr.errors import CannotOverwriteExistingCassetteException
@@ -195,11 +195,11 @@ def test_gzip(get_client, tmpdir, scheme):
 
     with vcr.use_cassette(str(tmpdir.join("gzip.yaml"))):
         response = yield get(get_client(), url, **kwargs)
-        assert_is_json(response.body)
+        assert_is_json_bytes(response.body)
 
     with vcr.use_cassette(str(tmpdir.join("gzip.yaml"))) as cass:
         response = yield get(get_client(), url, **kwargs)
-        assert_is_json(response.body)
+        assert_is_json_bytes(response.body)
         assert 1 == cass.play_count
 
 

--- a/tests/integration/test_urllib3.py
+++ b/tests/integration/test_urllib3.py
@@ -4,7 +4,7 @@
 
 import pytest
 import pytest_httpbin
-from assertions import assert_cassette_empty, assert_is_json
+from assertions import assert_cassette_empty, assert_is_json_bytes
 
 import vcr
 from vcr.patch import force_reset
@@ -136,10 +136,10 @@ def test_gzip(tmpdir, httpbin_both, verify_pool_mgr):
 
     with vcr.use_cassette(str(tmpdir.join("gzip.yaml"))):
         response = verify_pool_mgr.request("GET", url)
-        assert_is_json(response.data)
+        assert_is_json_bytes(response.data)
 
     with vcr.use_cassette(str(tmpdir.join("gzip.yaml"))):
-        assert_is_json(response.data)
+        assert_is_json_bytes(response.data)
 
 
 def test_https_with_cert_validation_disabled(tmpdir, httpbin_secure, pool_mgr):


### PR DESCRIPTION
Parameter name `a_string` was mistaken and function name `assert_is_json` was less clear than ideal, given that it explicitly needs bytes unlike `json.loads`.