### PR TITLE
Make `json.loads` of Python >=3.6 decode bytes by itself

### DIFF
--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -15,7 +15,7 @@ def assert_is_json_bytes(b: bytes):
     assert isinstance(b, bytes)
 
     try:
-        json.loads(b.decode("utf-8"))
+        json.loads(b)
     except Exception as error:
         raise AssertionError() from error
 

--- a/tests/integration/test_stubs.py
+++ b/tests/integration/test_stubs.py
@@ -120,8 +120,8 @@ def test_original_response_is_not_modified_by_before_filter(tmpdir, httpbin):
 
         # The scrubbed field should be the same, because no cassette existed.
         # Furthermore, the responses should be identical.
-        inside_body = json.loads(inside.read().decode("utf-8"))
-        outside_body = json.loads(outside.read().decode("utf-8"))
+        inside_body = json.loads(inside.read())
+        outside_body = json.loads(outside.read())
         assert not inside_body[field_to_scrub] == replacement
         assert inside_body[field_to_scrub] == outside_body[field_to_scrub]
 
@@ -131,5 +131,5 @@ def test_original_response_is_not_modified_by_before_filter(tmpdir, httpbin):
         conn.request("GET", "/get")
         inside = conn.getresponse()
 
-        inside_body = json.loads(inside.read().decode("utf-8"))
+        inside_body = json.loads(inside.read())
         assert inside_body[field_to_scrub] == replacement

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -197,7 +197,7 @@ def test_replace_json_post_data_parameters():
             ("six", "doesntexist"),
         ],
     )
-    request_data = json.loads(request.body.decode("utf-8"))
+    request_data = json.loads(request.body)
     expected_data = json.loads('{"one": "keep", "three": "tada", "four": "SHOUT"}')
     assert request_data == expected_data
 
@@ -208,8 +208,8 @@ def test_remove_json_post_data_parameters():
     request = Request("POST", "http://google.com", body, {})
     request.headers["Content-Type"] = "application/json"
     remove_post_data_parameters(request, ["id"])
-    request_body_json = json.loads(request.body.decode("utf-8"))
-    expected_json = json.loads(b'{"foo": "bar", "baz": "qux"}'.decode("utf-8"))
+    request_body_json = json.loads(request.body)
+    expected_json = json.loads(b'{"foo": "bar", "baz": "qux"}')
     assert request_body_json == expected_json
 
 

--- a/vcr/filters.py
+++ b/vcr/filters.py
@@ -95,7 +95,7 @@ def replace_post_data_parameters(request, replacements):
                         new_body[k] = rv
             request.body = new_body
         elif request.headers.get("Content-Type") == "application/json":
-            json_data = json.loads(request.body.decode("utf-8"))
+            json_data = json.loads(request.body)
             for k, rv in replacements.items():
                 if k in json_data:
                     ov = json_data.pop(k)

--- a/vcr/matchers.py
+++ b/vcr/matchers.py
@@ -73,11 +73,8 @@ def _header_checker(value, header="Content-Type"):
 
 
 def _transform_json(body):
-    # Request body is always a byte string, but json.loads() wants a text
-    # string. RFC 7159 says the default encoding is UTF-8 (although UTF-16
-    # and UTF-32 are also allowed: hmmmmm).
     if body:
-        return json.loads(body.decode("utf-8"))
+        return json.loads(body)
 
 
 _xml_header_checker = _header_checker("text/xml")


### PR DESCRIPTION
Quoting https://docs.python.org/3/library/json.html#json.loads :
> Changed in version 3.6: s can now be of type bytes or bytearray.
> The input encoding should be UTF-8, UTF-16 or UTF-32.