### PR TITLE
Move httpx monkeypatching to a lower layer to allow recording request generated by auth flows.

### DIFF
--- a/tests/integration/cassettes/test_httpx_test_test_auth_flow.yml
+++ b/tests/integration/cassettes/test_httpx_test_test_auth_flow.yml
@@ -1,0 +1,155 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      host:
+      - mockbin.org
+      user-agent:
+      - python-httpx/0.24.1
+    method: GET
+    uri: https://mockbin.org/headers?foo=bar
+  response:
+    content: "{\n  \"headers\": [\n    {\n      \"name\": \"host\",\n      \"value\":
+      \"mockbin.org\"\n    },\n    {\n      \"name\": \"connection\",\n      \"value\":
+      \"close\"\n    },\n    {\n      \"name\": \"accept-encoding\",\n      \"value\":
+      \"gzip\"\n    },\n    {\n      \"name\": \"x-forwarded-for\",\n      \"value\":
+      \"188.24.111.114, 162.158.19.72\"\n    },\n    {\n      \"name\": \"cf-ray\",\n
+      \     \"value\": \"7e4c4af4c861989d-OTP\"\n    },\n    {\n      \"name\": \"x-forwarded-proto\",\n
+      \     \"value\": \"http\"\n    },\n    {\n      \"name\": \"cf-visitor\",\n
+      \     \"value\": \"{\\\"scheme\\\":\\\"https\\\"}\"\n    },\n    {\n      \"name\":
+      \"accept\",\n      \"value\": \"*/*\"\n    },\n    {\n      \"name\": \"user-agent\",\n
+      \     \"value\": \"python-httpx/0.24.1\"\n    },\n    {\n      \"name\": \"cdn-loop\",\n
+      \     \"value\": \"cloudflare\"\n    },\n    {\n      \"name\": \"cf-connecting-ip\",\n
+      \     \"value\": \"188.24.111.114\"\n    },\n    {\n      \"name\": \"x-request-id\",\n
+      \     \"value\": \"30cd4a6f-b1e6-4100-b7b3-5cfe88bbc75c\"\n    },\n    {\n      \"name\":
+      \"x-forwarded-port\",\n      \"value\": \"80\"\n    },\n    {\n      \"name\":
+      \"via\",\n      \"value\": \"1.1 vegur\"\n    },\n    {\n      \"name\": \"connect-time\",\n
+      \     \"value\": \"0\"\n    },\n    {\n      \"name\": \"x-request-start\",\n
+      \     \"value\": \"1689028662710\"\n    },\n    {\n      \"name\": \"total-route-time\",\n
+      \     \"value\": \"0\"\n    }\n  ],\n  \"headersSize\": 507\n}"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - host,connection,accept-encoding,x-forwarded-for,cf-ray,x-forwarded-proto,cf-visitor,accept,user-agent,cdn-loop,cf-connecting-ip,x-request-id,x-forwarded-port,via,connect-time,x-request-start,total-route-time
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 7e4c4af4c861989d-OTP
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - br
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 10 Jul 2023 22:37:42 GMT
+      Etag:
+      - W/"4f6-96wYR+WtOzQwNmsxI2xsQ0itcVk"
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=3Wn4%2BfN7FpKt461dFo1USOwFRcoH5KBIxOkbPEe7zTN1E56LjvSVlMi57x%2FN6NgAHhUrSqrQdh5JizM%2BvQ%2FFydbxBnrtca6GwAH4VnfGO67kUppgOa%2BVEz%2FVZkDAsA%3D%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept, Accept-Encoding
+      Via:
+      - 1.1 vegur
+      X-Powered-By:
+      - mockbin
+      alt-svc:
+      - h3=":443"; ma=86400
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      foobar:
+      - somethingsomething
+      host:
+      - mockbin.org
+      user-agent:
+      - python-httpx/0.24.1
+    method: GET
+    uri: https://mockbin.org/headers
+  response:
+    content: "{\n  \"headers\": [\n    {\n      \"name\": \"host\",\n      \"value\":
+      \"mockbin.org\"\n    },\n    {\n      \"name\": \"connection\",\n      \"value\":
+      \"close\"\n    },\n    {\n      \"name\": \"accept-encoding\",\n      \"value\":
+      \"gzip\"\n    },\n    {\n      \"name\": \"x-forwarded-for\",\n      \"value\":
+      \"188.24.111.114, 162.158.19.71\"\n    },\n    {\n      \"name\": \"cf-ray\",\n
+      \     \"value\": \"7e4c4af669c6989d-OTP\"\n    },\n    {\n      \"name\": \"x-forwarded-proto\",\n
+      \     \"value\": \"http\"\n    },\n    {\n      \"name\": \"cf-visitor\",\n
+      \     \"value\": \"{\\\"scheme\\\":\\\"https\\\"}\"\n    },\n    {\n      \"name\":
+      \"accept\",\n      \"value\": \"*/*\"\n    },\n    {\n      \"name\": \"user-agent\",\n
+      \     \"value\": \"python-httpx/0.24.1\"\n    },\n    {\n      \"name\": \"foobar\",\n
+      \     \"value\": \"somethingsomething\"\n    },\n    {\n      \"name\": \"cdn-loop\",\n
+      \     \"value\": \"cloudflare\"\n    },\n    {\n      \"name\": \"cf-connecting-ip\",\n
+      \     \"value\": \"188.24.111.114\"\n    },\n    {\n      \"name\": \"x-request-id\",\n
+      \     \"value\": \"3d014b63-7b92-40f3-b7a1-416f8176bd91\"\n    },\n    {\n      \"name\":
+      \"x-forwarded-port\",\n      \"value\": \"80\"\n    },\n    {\n      \"name\":
+      \"via\",\n      \"value\": \"1.1 vegur\"\n    },\n    {\n      \"name\": \"connect-time\",\n
+      \     \"value\": \"0\"\n    },\n    {\n      \"name\": \"x-request-start\",\n
+      \     \"value\": \"1689028662976\"\n    },\n    {\n      \"name\": \"total-route-time\",\n
+      \     \"value\": \"0\"\n    }\n  ],\n  \"headersSize\": 527\n}"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - host,connection,accept-encoding,x-forwarded-for,cf-ray,x-forwarded-proto,cf-visitor,accept,user-agent,foobar,cdn-loop,cf-connecting-ip,x-request-id,x-forwarded-port,via,connect-time,x-request-start,total-route-time
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 7e4c4af669c6989d-OTP
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - br
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 10 Jul 2023 22:37:43 GMT
+      Etag:
+      - W/"53f-HCiVPpHhNS0OvxIv/sdjrKK3RBU"
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=GFYfXYWls15MeC2cw7WbFcEZh8XRTw4BYV2MzDlpbyvD8oPXPs8eulWKDohu4F%2FtYHAOGW79g%2BCad9V1XfTKFrDZIMnS0nHGFDfxikSyjM9rOfN1%2FK%2BIl2dUUobI4A%3D%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept, Accept-Encoding
+      Via:
+      - 1.1 vegur
+      X-Powered-By:
+      - mockbin
+      alt-svc:
+      - h3=":443"; ma=86400
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/integration/test_httpx.py
+++ b/tests/integration/test_httpx.py
@@ -239,15 +239,13 @@ def test_behind_proxy(do_request):
 
 
 def test_auth_flow(do_request):
-    yml = (
-        os.path.dirname(os.path.realpath(__file__)) + "/cassettes/" + "test_httpx_test_test_auth_flow.yml"
-    )
+    yml = os.path.dirname(os.path.realpath(__file__)) + "/cassettes/" + "test_httpx_test_test_auth_flow.yml"
     url = "https://mockbin.org/headers"
     client = None
 
     class AuthWithExtraRequest(httpx.Auth):
         def auth_flow(self, request):
-            response = yield client.client.build_request("GET", url, params={'foo': 'bar'})
+            response = yield client.client.build_request("GET", url, params={"foo": "bar"})
             assert response
             request.headers["Foobar"] = "somethingsomething"
             yield request
@@ -262,7 +260,7 @@ def test_auth_flow(do_request):
         assert str(cassette_response.request.url) == url
         assert cassette.play_count == 2
 
-        headers = cassette_response.json()['headers']
+        headers = cassette_response.json()["headers"]
         for header in headers:
             if header["name"] == "foobar":
                 assert header["value"] == "somethingsomething"

--- a/vcr/patch.py
+++ b/vcr/patch.py
@@ -103,8 +103,8 @@ try:
 except ImportError:  # pragma: no cover
     pass
 else:
-    _HttpxSyncClient_send = httpx.Client.send
-    _HttpxAsyncClient_send = httpx.AsyncClient.send
+    _HttpxSyncClient_send = httpx.Client._send_handling_redirects
+    _HttpxAsyncClient_send = httpx.AsyncClient._send_handling_redirects
 
 
 class CassettePatcherBuilder:
@@ -328,10 +328,10 @@ class CassettePatcherBuilder:
             from .stubs.httpx_stubs import async_vcr_send, sync_vcr_send
 
             new_async_client_send = async_vcr_send(self._cassette, _HttpxAsyncClient_send)
-            yield httpx.AsyncClient, "send", new_async_client_send
+            yield httpx.AsyncClient, "_send_handling_redirects", new_async_client_send
 
             new_sync_client_send = sync_vcr_send(self._cassette, _HttpxSyncClient_send)
-            yield httpx.Client, "send", new_sync_client_send
+            yield httpx.Client, "_send_handling_redirects", new_sync_client_send
 
     def _urllib3_patchers(self, cpool, conn, stubs):
         http_connection_remover = ConnectionRemover(

--- a/vcr/stubs/httpx_stubs.py
+++ b/vcr/stubs/httpx_stubs.py
@@ -141,6 +141,7 @@ async def _async_vcr_send(cassette, real_send, *args, **kwargs):
         return response
 
     real_response = await real_send(*args, **kwargs)
+    await real_response.aread()
     return _record_responses(cassette, vcr_request, real_response)
 
 
@@ -160,6 +161,7 @@ def _sync_vcr_send(cassette, real_send, *args, **kwargs):
         return response
 
     real_response = real_send(*args, **kwargs)
+    real_response.read()
     return _record_responses(cassette, vcr_request, real_response)
 
 


### PR DESCRIPTION
Not sure if i wrote the test correctly but that test suite is way over my head.

I would like to note that the monkeypatching should be moved even lower but then there's some complicated redirect handling that I can't untangle.

Should fix #684.