### PR TITLE
Remove unnecessary dependency on six.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ class PyTest(TestCommand):
 install_requires = [
     "PyYAML",
     "wrapt",
-    "six>=1.5",
     "yarl",
     # Support for urllib3 >=2 needs Python >=3.10
     # so we need to block urllib3 >=2 for Python <3.10 for now.

--- a/vcr/config.py
+++ b/vcr/config.py
@@ -6,8 +6,6 @@ import types
 from collections import abc as collections_abc
 from pathlib import Path
 
-import six
-
 from . import filters, matchers
 from .cassette import Cassette
 from .persisters.filesystem import FilesystemPersister
@@ -256,5 +254,5 @@ class VCR:
 
     def test_case(self, predicate=None):
         predicate = predicate or self.is_test_method
-        # TODO: Remove this reference to `six` in favor of the Python3 equivalent
-        return six.with_metaclass(auto_decorate(self.use_cassette, predicate))
+        metaclass = auto_decorate(self.use_cassette, predicate)
+        return metaclass("temporary_class", (), {})


### PR DESCRIPTION
Remove the last remaining usage of it in VCR.testcase.