### PR TITLE
Enable testing on Python 3.12 & PyPy 3.9/3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev", "pypy-3.8"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev", "pypy-3.8", "pypy-3.9", "pypy-3.10"]
 
     steps:
       - uses: actions/checkout@v3.5.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy-3.8"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev", "pypy-3.8"]
 
     steps:
       - uses: actions/checkout@v3.5.2

--- a/tox.ini
+++ b/tox.ini
@@ -81,3 +81,7 @@ passenv =
     AWS_ACCESS_KEY_ID
     AWS_DEFAULT_REGION
     AWS_SECRET_ACCESS_KEY
+setenv =
+    # workaround for broken C extension in aiohttp
+    # see: https://github.com/aio-libs/aiohttp/issues/7229
+    py312: AIOHTTP_NO_EXTENSIONS=1

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ skip_missing_interpreters=true
 envlist =
   cov-clean,
   lint,
-  {py38,py39,py310,py311}-{requests-urllib3-1,httplib2,urllib3-1,tornado4,boto3,aiohttp,httpx},
-  {py310,py311}-{requests-urllib3-2,urllib3-2},
+  {py38,py39,py310,py311,py312}-{requests-urllib3-1,httplib2,urllib3-1,tornado4,boto3,aiohttp,httpx},
+  {py310,py311,py312}-{requests-urllib3-2,urllib3-2},
   {pypy3}-{requests-urllib3-1,httplib2,urllib3-1,tornado4,boto3},
   {py310}-httpx019,
   cov-report
@@ -16,6 +16,7 @@ python =
     3.9: py39
     3.10: py310, lint
     3.11: py311
+    3.12: py312
     pypy-3: pypy3
 
 # Coverage environment tasks: cov-clean and cov-report
@@ -74,8 +75,8 @@ deps =
     httpx019: httpx==0.19
     {py38,py39,py310}-{httpx}: pytest-asyncio
 depends =
-  lint,{py38,py39,py310,py311,pypy3}-{requests-urllib3-1,httplib2,urllib3-1,tornado4,boto3},{py310,py311}-{requests-urllib3-2,urllib3-2},{py38,py39,py310,py311}-{aiohttp},{py38,py39,py310,py311}-{httpx}: cov-clean
-  cov-report: lint,{py38,py39,py310,py311,pypy3}-{requests-urllib3-1,httplib2,urllib3-1,tornado4,boto3},{py310,py311}-{requests-urllib3-2,urllib3-2},{py38,py39,py310,py311}-{aiohttp}
+  lint,{py38,py39,py310,py311,py312,pypy3}-{requests-urllib3-1,httplib2,urllib3-1,tornado4,boto3},{py310,py311,py312}-{requests-urllib3-2,urllib3-2},{py38,py39,py310,py311,py312}-{aiohttp},{py38,py39,py310,py311,py312}-{httpx}: cov-clean
+  cov-report: lint,{py38,py39,py310,py311,py312,pypy3}-{requests-urllib3-1,httplib2,urllib3-1,tornado4,boto3},{py310,py311,py312}-{requests-urllib3-2,urllib3-2},{py38,py39,py310,py311,py312}-{aiohttp}
 passenv =
     AWS_ACCESS_KEY_ID
     AWS_DEFAULT_REGION

--- a/vcr/stubs/__init__.py
+++ b/vcr/stubs/__init__.py
@@ -389,6 +389,8 @@ class VCRHTTPConnection(VCRConnection):
 
     _baseclass = HTTPConnection
     _protocol = "http"
+    debuglevel = _baseclass.debuglevel
+    _http_vsn = _baseclass._http_vsn
 
 
 class VCRHTTPSConnection(VCRConnection):
@@ -397,3 +399,5 @@ class VCRHTTPSConnection(VCRConnection):
     _baseclass = HTTPSConnection
     _protocol = "https"
     is_verified = True
+    debuglevel = _baseclass.debuglevel
+    _http_vsn = _baseclass._http_vsn


### PR DESCRIPTION
As requested in https://github.com/kevin1024/vcrpy/issues/707#issuecomment-1662706535.

I've also noticed that PyPy3.9 and 3.10 were missing, so added them as well.