### PR TITLE
Fix ResourceWarning unclosed socket

### DIFF
--- a/vcr/patch.py
+++ b/vcr/patch.py
@@ -367,6 +367,7 @@ class ConnectionRemover:
     def add_connection_to_pool_entry(self, pool, connection):
         if isinstance(connection, self._connection_class):
             self._connection_pool_to_connections.setdefault(pool, set()).add(connection)
+            pool._put_conn(connection)
 
     def remove_connection_to_pool_entry(self, pool, connection):
         if isinstance(connection, self._connection_class):
@@ -382,6 +383,7 @@ class ConnectionRemover:
                 connection = pool.pool.get()
                 if isinstance(connection, self._connection_class):
                     connections.remove(connection)
+                    connection.close()
                 else:
                     readd_connections.append(connection)
             for connection in readd_connections:


### PR DESCRIPTION
This PR fixes issue #710 by properly closing the underlying socket. It first uses `pool._put_conn` to keep the connection in the pool, and later removes and closes it when the context manager exits.

I was unsure about the exact purpose of the `ConnectonRemove` class, so I made minimal changes to minimize the risk of breaking the code and there may be better solutions for fixing this issue.

For example, the `urllib3.connectionpool.HTTPConnectionPool` will utilize a weakref to terminate pool connections. By appending our connection to it, it will also take care of closing our connection. So another solution could be to modify the `__exit__` in `patch.ConnectionRemover` method and add our connection to the pool:

```py
class ConnectionRemover:
    ...

    def __exit__(self, *args):
        for pool, connections in self._connection_pool_to_connections.items():
            for connection in connections:
                if isinstance(connection, self._connection_class):
                    pool._put_conn(connection)
```