### PR TITLE
Expose Request object so we can see if a replay occurred.

### DIFF
--- a/vcr/__init__.py
+++ b/vcr/__init__.py
@@ -3,6 +3,7 @@ from logging import NullHandler
 
 from .config import VCR
 from .record_mode import RecordMode as mode  # noqa: F401
+from .request import Request
 
 __version__ = "5.1.0"
 


### PR DESCRIPTION
In some cases, we need to determine if the actual request was invoked or the cached version was returned. In order to do that, we need to do an evolution of #394. We need to reconstruct the underlying `Request` object:

```python
def make_vcr_request(req):
      body = req.read().decode("utf-8")
      uri = str(req.url)
      headers = dict(req.headers)
      return Request(req.method, uri, body, headers)


self._current_request_used_cache = self.cassete.can_play_response_for(make_vcr_request(request))
```

To do that, we need VCR's `Request` object exposed in the package. 

**This PR simply exposes that `Request` object for use. Open to thoughts on how to better accomplish this by folks that know this tool better.**