### PR TITLE
httpx: use surrogateescape to allow for binary data

### DIFF
--- a/vcr/request.py
+++ b/vcr/request.py
@@ -41,7 +41,7 @@ class Request:
     @body.setter
     def body(self, value):
         if isinstance(value, str):
-            value = value.encode("utf-8")
+            value = value.encode("utf-8", errors="surrogateescape")
         self._body = value
 
     def add_header(self, key, value):

--- a/vcr/stubs/httpx_stubs.py
+++ b/vcr/stubs/httpx_stubs.py
@@ -70,7 +70,7 @@ def _from_serialized_response(request, serialized_response, history=None):
 
 
 def _make_vcr_request(httpx_request, **kwargs):
-    body = httpx_request.read().decode("utf-8")
+    body = httpx_request.read().decode("utf-8", errors="surrogateescape")
     uri = str(httpx_request.url)
     headers = dict(httpx_request.headers)
     return VcrRequest(httpx_request.method, uri, body, headers)


### PR DESCRIPTION
This allows recording httpx requests with binary data in the request
body.

Fixes: https://github.com/kevin1024/vcrpy/issues/656