### PR TITLE
Add an option to remove unused requests from cassette

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -438,4 +438,4 @@ option to ``True``, VCR will not save old HTTP interactions if they are not used
 
     my_vcr = VCR(drop_unused_requests=True)
     with my_vcr.use_cassette('fixtures/vcr_cassettes/synopsis.yaml'):
-        # your http here
+        ...  # your HTTP interactions here

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -426,3 +426,16 @@ If you want to save the cassette only when the test succeedes, set the Cassette
 
     # Since there was an exception, the cassette file hasn't been created.
     assert not os.path.exists('fixtures/vcr_cassettes/synopsis.yaml')
+
+Drop unused requests
+--------------------
+
+Even if any HTTP request is changed or removed from tests, previously recorded
+interactions remain in the cassette file.  If set the ``drop_unused_requests``
+option to ``True``, VCR will not save old HTTP interactions if they are not used.
+
+.. code:: python
+
+    my_vcr = VCR(drop_unused_requests=True)
+    with my_vcr.use_cassette('fixtures/vcr_cassettes/synopsis.yaml'):
+        # your http here

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -5,6 +5,7 @@ from urllib.request import urlopen
 import pytest
 
 import vcr
+from vcr.cassette import Cassette
 
 
 def test_set_serializer_default_config(tmpdir, httpbin):
@@ -80,3 +81,20 @@ def test_dont_record_on_exception(tmpdir):
             assert b"Not in content" in urlopen("http://httpbin.org/get").read()
 
     assert not os.path.exists(str(tmpdir.join("dontsave2.yml")))
+
+def test_set_drop_unused_requests(tmpdir, httpbin):
+    my_vcr = vcr.VCR(drop_unused_requests=True)
+    file = str(tmpdir.join("test.yaml"))
+
+    with my_vcr.use_cassette(file):
+        urlopen(httpbin.url)
+        urlopen(httpbin.url + "/get")
+
+    cassette = Cassette.load(path=file)
+    assert len(cassette) == 2
+
+    with my_vcr.use_cassette(file):
+        urlopen(httpbin.url)
+
+    cassette = Cassette.load(path=file)
+    assert len(cassette) == 1

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -82,6 +82,7 @@ def test_dont_record_on_exception(tmpdir):
 
     assert not os.path.exists(str(tmpdir.join("dontsave2.yml")))
 
+
 def test_set_drop_unused_requests(tmpdir, httpbin):
     my_vcr = vcr.VCR(drop_unused_requests=True)
     file = str(tmpdir.join("test.yaml"))

--- a/tests/unit/test_cassettes.py
+++ b/tests/unit/test_cassettes.py
@@ -401,7 +401,7 @@ def test_used_interactions(tmpdir):
     interactions = [
         {"request": {"body": "", "uri": "foo1", "method": "GET", "headers": {}}, "response": "bar1"},
         {"request": {"body": "", "uri": "foo2", "method": "GET", "headers": {}}, "response": "bar2"},
-        {"request": {"body": "", "uri": "foo3", "method": "GET", "headers": {}}, "response": "bar3"}
+        {"request": {"body": "", "uri": "foo3", "method": "GET", "headers": {}}, "response": "bar3"},
     ]
     file = tmpdir.join("test_cassette.yml")
     file.write(yaml.dump({"interactions": [interactions[0], interactions[1]]}))

--- a/tests/unit/test_cassettes.py
+++ b/tests/unit/test_cassettes.py
@@ -11,6 +11,7 @@ import yaml
 from vcr.cassette import Cassette
 from vcr.errors import UnhandledHTTPRequestError
 from vcr.patch import force_reset
+from vcr.request import Request
 from vcr.stubs import VCRHTTPSConnection
 
 
@@ -394,3 +395,25 @@ def test_find_requests_with_most_matches_many_similar_requests(mock_get_matchers
         (1, ["method", "path"], [("query", "failed : query")]),
         (3, ["method", "path"], [("query", "failed : query")]),
     ]
+
+
+def test_used_interactions(tmpdir):
+    interactions = [
+        {"request": {"body": "", "uri": "foo1", "method": "GET", "headers": {}}, "response": "bar1"},
+        {"request": {"body": "", "uri": "foo2", "method": "GET", "headers": {}}, "response": "bar2"},
+        {"request": {"body": "", "uri": "foo3", "method": "GET", "headers": {}}, "response": "bar3"}
+    ]
+    file = tmpdir.join("test_cassette.yml")
+    file.write(yaml.dump({"interactions": [interactions[0], interactions[1]]}))
+
+    cassette = Cassette.load(path=str(file))
+    request = Request._from_dict(interactions[1]["request"])
+    cassette.play_response(request)
+    assert len(cassette._played_interactions) < len(cassette._old_interactions)
+
+    request = Request._from_dict(interactions[2]["request"])
+    cassette.append(request, interactions[2]["response"])
+    assert len(cassette._new_interactions()) == 1
+
+    used_interactions = cassette._played_interactions + cassette._new_interactions()
+    assert len(used_interactions) == 2

--- a/vcr/cassette.py
+++ b/vcr/cassette.py
@@ -348,8 +348,10 @@ class Cassette:
         """List of new HTTP interactions (request/response tuples)"""
         new_interactions = []
         for request, response in self.data:
-            if all(not requests_match(request, old_request, self._match_on)
-                   for old_request, _ in self._old_interactions):
+            if all(
+                not requests_match(request, old_request, self._match_on)
+                for old_request, _ in self._old_interactions
+            ):
                 new_interactions.append((request, response))
         return new_interactions
 
@@ -363,7 +365,7 @@ class Cassette:
         return {"requests": requests, "responses": responses}
 
     def _save(self, force=False):
-        if (len(self._played_interactions) < len(self._old_interactions)):
+        if len(self._played_interactions) < len(self._old_interactions):
             force = True
         if force or self.dirty:
             self._persister.save_cassette(self._path, self._as_dict(), serializer=self._serializer)

--- a/vcr/cassette.py
+++ b/vcr/cassette.py
@@ -197,6 +197,7 @@ class Cassette:
         custom_patches=(),
         inject=False,
         allow_playback_repeats=False,
+        drop_unused_requests=False,
     ):
         self._persister = persister or FilesystemPersister
         self._path = path
@@ -209,12 +210,17 @@ class Cassette:
         self.record_mode = record_mode
         self.custom_patches = custom_patches
         self.allow_playback_repeats = allow_playback_repeats
+        self.drop_unused_requests = drop_unused_requests
 
         # self.data is the list of (req, resp) tuples
         self.data = []
         self.play_counts = collections.Counter()
         self.dirty = False
         self.rewound = False
+
+        # Subsets of self.data to store old and played interactions
+        self._old_interactions = []
+        self._played_interactions = []
 
     @property
     def play_count(self):
@@ -277,6 +283,7 @@ class Cassette:
         for index, response in self._responses(request):
             if self.play_counts[index] == 0 or self.allow_playback_repeats:
                 self.play_counts[index] += 1
+                self._played_interactions.append((request, response))
                 return response
         # The cassette doesn't contain the request asked for.
         raise UnhandledHTTPRequestError(
@@ -337,10 +344,27 @@ class Cassette:
 
         return final_best_matches
 
+    def _new_interactions(self):
+        """List of new HTTP interactions (request/response tuples)"""
+        new_interactions = []
+        for request, response in self.data:
+            if all(not requests_match(request, old_request, self._match_on)
+                   for old_request, _ in self._old_interactions):
+                new_interactions.append((request, response))
+        return new_interactions
+
     def _as_dict(self):
-        return {"requests": self.requests, "responses": self.responses}
+        requests = self.requests
+        responses = self.responses
+        if self.drop_unused_requests:
+            interactions = self._played_interactions + self._new_interactions()
+            requests = [request for request, _ in interactions]
+            responses = [response for _, response in interactions]
+        return {"requests": requests, "responses": responses}
 
     def _save(self, force=False):
+        if (len(self._played_interactions) < len(self._old_interactions)):
+            force = True
         if force or self.dirty:
             self._persister.save_cassette(self._path, self._as_dict(), serializer=self._serializer)
             self.dirty = False
@@ -350,6 +374,7 @@ class Cassette:
             requests, responses = self._persister.load_cassette(self._path, serializer=self._serializer)
             for request, response in zip(requests, responses):
                 self.append(request, response)
+                self._old_interactions.append((request, response))
             self.dirty = False
             self.rewound = True
         except ValueError:

--- a/vcr/cassette.py
+++ b/vcr/cassette.py
@@ -365,7 +365,7 @@ class Cassette:
         return {"requests": requests, "responses": responses}
 
     def _save(self, force=False):
-        if len(self._played_interactions) < len(self._old_interactions):
+        if self.drop_unused_requests and len(self._played_interactions) < len(self._old_interactions):
             force = True
         if force or self.dirty:
             self._persister.save_cassette(self._path, self._as_dict(), serializer=self._serializer)

--- a/vcr/cassette.py
+++ b/vcr/cassette.py
@@ -356,19 +356,24 @@ class Cassette:
         return new_interactions
 
     def _as_dict(self):
-        requests = self.requests
-        responses = self.responses
-        if self.drop_unused_requests:
-            interactions = self._played_interactions + self._new_interactions()
-            requests = [request for request, _ in interactions]
-            responses = [response for _, response in interactions]
-        return {"requests": requests, "responses": responses}
+        return {"requests": self.requests, "responses": self.responses}
+
+    def _build_used_interactions_dict(self):
+        interactions = self._played_interactions + self._new_interactions()
+        cassete_dict = {
+            "requests": [request for request, _ in interactions],
+            "responses": [response for _, response in interactions],
+        }
+        return cassete_dict
 
     def _save(self, force=False):
         if self.drop_unused_requests and len(self._played_interactions) < len(self._old_interactions):
+            cassete_dict = self._build_used_interactions_dict()
             force = True
+        else:
+            cassete_dict = self._as_dict()
         if force or self.dirty:
-            self._persister.save_cassette(self._path, self._as_dict(), serializer=self._serializer)
+            self._persister.save_cassette(self._path, cassete_dict, serializer=self._serializer)
             self.dirty = False
 
     def _load(self):

--- a/vcr/config.py
+++ b/vcr/config.py
@@ -50,6 +50,7 @@ class VCR:
         func_path_generator=None,
         decode_compressed_response=False,
         record_on_exception=True,
+        drop_unused_requests=False,
     ):
         self.serializer = serializer
         self.match_on = match_on
@@ -83,6 +84,7 @@ class VCR:
         self.decode_compressed_response = decode_compressed_response
         self.record_on_exception = record_on_exception
         self._custom_patches = tuple(custom_patches)
+        self.drop_unused_requests = drop_unused_requests
 
     def _get_serializer(self, serializer_name):
         try:
@@ -153,6 +155,7 @@ class VCR:
             "func_path_generator": func_path_generator,
             "allow_playback_repeats": kwargs.get("allow_playback_repeats", False),
             "record_on_exception": record_on_exception,
+            "drop_unused_requests": kwargs.get("drop_unused_requests", self.drop_unused_requests),
         }
         path = kwargs.get("path")
         if path:


### PR DESCRIPTION
This PR adds an option to remove previously recorded interactions if they are not used. I believe this feature can address the issue discussed in #208. We don't need to focus on ignoring all requests in the cassette file, but instead, we can write to file only replayed interactions and new ones. If no previous request is used, VCR will save only new interactions.

There is a [similar feature](https://github.com/vcr/vcr/pull/946) in Ruby VCR.

Replaces #677 