### PR TITLE
docs: Fix deprecated `intersphinx_mapping` format

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -316,5 +316,5 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/": None}
+intersphinx_mapping = {"python": ("https://docs.python.org/3/", None)}
 html_theme = "alabaster"


### PR DESCRIPTION
While working on #771, I noticed that Sphinx is logging a warning on builds because the format being used for `intersphinx_mapping` is deprecated and will be removed in the next major release of Sphinx:

```
WARNING: The pre-Sphinx 1.0 'intersphinx_mapping' format is deprecated and will be removed in Sphinx 8. Update to the current format as described in the documentation. Hint: "intersphinx_mapping = {'<name>': ('https://docs.python.org/', None)}".https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping
```

This updates the format for `intersphinx_mapping` to use the newer, actively maintained format. (I’m not this matters too much, though, since there are no type annotations and none of the docstrings list types for intersphinx to make links out of. 🤷)