### PR TITLE
Uncap urllib3 version on Python < 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,13 +46,6 @@ install_requires = [
     "PyYAML",
     "wrapt",
     "yarl",
-    # Support for urllib3 >=2 needs Python >=3.10
-    # so we need to block urllib3 >=2 for Python <3.10 for now.
-    # Note that vcrpy would work fine without any urllib3 around,
-    # so this block and the dependency can be dropped at some point
-    # in the future. For more Details:
-    # https://github.com/kevin1024/vcrpy/pull/699#issuecomment-1551439663
-    "urllib3 <2; python_version <'3.10'",
 ]
 
 tests_require = [

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
   cov-clean,
   lint,
   {py38,py39,py310,py311,py312}-{requests-urllib3-1,httplib2,urllib3-1,tornado4,boto3,aiohttp,httpx},
-  {py310,py311,py312}-{requests-urllib3-2,urllib3-2},
+  {py38,py39,py310,py311,py312}-{requests-urllib3-2,urllib3-2},
   {pypy3}-{requests-urllib3-1,httplib2,urllib3-1,tornado4,boto3},
   #{py310}-httpx019,
   cov-report


### PR DESCRIPTION
Between myself and another maintainer of our downstream project, we've tested Python 3.8 & 3.9 with both OpenSSL 1.1.1 and 3.0.2, using vcrpy 5.1.0 and a forcibly upgraded urllib3 2.0.6. Based on those results, I'm optimistically hoping that this incompatibility is resolved and https://github.com/kevin1024/vcrpy/pull/699#issuecomment-1563444199 has become true.

However, since the test suite already appears to fail on the current HEAD revision prior to applying this change, I'm not sure how to use the test results to definitively verify this patch (except by noting that in manual checks of the relevant environments I didn't see any _new_ failures as compared to running the same tox env on master).

Downstream, we plan to unblock ourselves on the cassette cross-compatibility problem we're having by adding a step to our CI that ensures urllib3 2.x prior to running tests—but if we're lucky, that will be only a temporary kludge.