### PR TITLE
feat: use regex for ignoring hosts

### DIFF
--- a/tests/integration/test_ignore.py
+++ b/tests/integration/test_ignore.py
@@ -44,6 +44,14 @@ def test_ignore_httpbin(tmpdir, httpbin):
             assert len(cass) == 1
 
 
+def test_ignore_httpbin_regex(tmpdir, httpbin):
+    with overridden_dns({"httpbin.org": "127.0.0.1"}):
+        cass_file = str(tmpdir.join("filter_qs.yaml"))
+        with vcr.use_cassette(cass_file, ignore_hosts=[r"h\w*bin.+"]) as cass:
+            urlopen(f"http://httpbin.org:{httpbin.port}/")
+            assert len(cass) == 0
+
+
 def test_ignore_localhost_and_httpbin(tmpdir, httpbin):
     with overridden_dns({"httpbin.org": "127.0.0.1"}):
         cass_file = str(tmpdir.join("filter_qs.yaml"))

--- a/vcr/config.py
+++ b/vcr/config.py
@@ -3,6 +3,7 @@ import functools
 import inspect
 import os
 import types
+import re
 from collections import abc as collections_abc
 from pathlib import Path
 
@@ -231,8 +232,10 @@ class VCR:
 
     @staticmethod
     def _build_ignore_hosts(hosts_to_ignore):
+        hosts_to_ignore_re = re.compile("(" + ")|(".join(hosts_to_ignore) + ")")
+
         def filter_ignored_hosts(request):
-            if hasattr(request, "host") and request.host in hosts_to_ignore:
+            if hasattr(request, "host") and bool(hosts_to_ignore_re.match(request.host)):
                 return
             return request
 


### PR DESCRIPTION
Allow to use regexes for `ignore_hosts` to easily ignore hosts that are frequently changed e.g. `pipelinesghubeus*.actions.githubusercontent.com`