### PR TITLE
Drop broken `pypy-3.10` (CI kept failing; alternative to #787)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev", "pypy-3.8", "pypy-3.9", "pypy-3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev", "pypy-3.8", "pypy-3.9"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
In reaction to https://github.com/kevin1024/vcrpy/pull/775#issuecomment-1847849962
Alternative to #787