### PR TITLE
tests: Fix imports to `tests/assertions.py` (fixes #773)

### DIFF
--- a/tests/integration/test_filter.py
+++ b/tests/integration/test_filter.py
@@ -5,9 +5,10 @@ from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 import pytest
-from assertions import assert_cassette_has_one_response, assert_is_json_bytes
 
 import vcr
+
+from ..assertions import assert_cassette_has_one_response, assert_is_json_bytes
 
 
 def _request_with_auth(url, username, password):

--- a/tests/integration/test_httplib2.py
+++ b/tests/integration/test_httplib2.py
@@ -3,9 +3,10 @@ from urllib.parse import urlencode
 
 import pytest
 import pytest_httpbin.certs
-from assertions import assert_cassette_has_one_response
 
 import vcr
+
+from ..assertions import assert_cassette_has_one_response
 
 httplib2 = pytest.importorskip("httplib2")
 

--- a/tests/integration/test_requests.py
+++ b/tests/integration/test_requests.py
@@ -1,8 +1,9 @@
 """Test requests' interaction with vcr"""
 import pytest
-from assertions import assert_cassette_empty, assert_is_json_bytes
 
 import vcr
+
+from ..assertions import assert_cassette_empty, assert_is_json_bytes
 
 requests = pytest.importorskip("requests")
 

--- a/tests/integration/test_stubs.py
+++ b/tests/integration/test_stubs.py
@@ -2,9 +2,9 @@ import http.client as httplib
 import json
 import zlib
 
-from assertions import assert_is_json_bytes
-
 import vcr
+
+from ..assertions import assert_is_json_bytes
 
 
 def _headers_are_case_insensitive(host, port):

--- a/tests/integration/test_tornado.py
+++ b/tests/integration/test_tornado.py
@@ -3,10 +3,11 @@
 import json
 
 import pytest
-from assertions import assert_cassette_empty, assert_is_json_bytes
 
 import vcr
 from vcr.errors import CannotOverwriteExistingCassetteException
+
+from ..assertions import assert_cassette_empty, assert_is_json_bytes
 
 tornado = pytest.importorskip("tornado")
 http = pytest.importorskip("tornado.httpclient")

--- a/tests/integration/test_urllib2.py
+++ b/tests/integration/test_urllib2.py
@@ -5,11 +5,12 @@ from urllib.parse import urlencode
 from urllib.request import urlopen
 
 import pytest_httpbin.certs
-from assertions import assert_cassette_has_one_response
 from pytest import mark
 
 # Internal imports
 import vcr
+
+from ..assertions import assert_cassette_has_one_response
 
 
 def urlopen_with_cafile(*args, **kwargs):

--- a/tests/integration/test_urllib3.py
+++ b/tests/integration/test_urllib3.py
@@ -4,11 +4,12 @@
 
 import pytest
 import pytest_httpbin
-from assertions import assert_cassette_empty, assert_is_json_bytes
 
 import vcr
 from vcr.patch import force_reset
 from vcr.stubs.compat import get_headers
+
+from ..assertions import assert_cassette_empty, assert_is_json_bytes
 
 urllib3 = pytest.importorskip("urllib3")
 


### PR DESCRIPTION
Fixes #773

Will need a rebase onto #786 or #787 after merge for a chance at a green CI.