### PR TITLE
support httpx chunked responses

### DIFF
--- a/vcr/stubs/httpx_stubs.py
+++ b/vcr/stubs/httpx_stubs.py
@@ -35,7 +35,12 @@ def _transform_headers(httpx_response):
 
 def _to_serialized_response(httpx_response):
     try:
-        content = httpx_response.content.decode("utf-8")
+        try:
+            content = httpx_response.content
+        except httpx.ResponseNotRead:
+            content = httpx_response.read()
+
+        content = content.decode("utf-8")
     except UnicodeDecodeError:
         content = httpx_response.content
 


### PR DESCRIPTION
Wasn't sure if there was a good test to add for this. I believe part of the issue in the existing test is that httpbin `/stream-bytes` doesn't support `Transfer-Encoding: chunked` unless run with gunicorn (see https://github.com/postmanlabs/httpbin/blob/63bf254118a242ee112a5d3ea209631909688ca5/httpbin/core.py#L1491, and https://github.com/postmanlabs/httpbin/blob/63bf254118a242ee112a5d3ea209631909688ca5/httpbin/core.py#L187-L195).

I tested adding this header to the httpbin endpoint and got this error
```
tests/integration/test_httpx.py:281: AssertionError
------------------------------------------------------------------------------------------------------- Captured stderr call --------------------------------------------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/tholub/.pyenv/versions/3.11.6/lib/python3.11/wsgiref/handlers.py", line 137, in run
    self.result = application(self.environ, self.start_response)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tholub/git/tysonholub/vcrpy/.tox/py311-httpx/lib/python3.11/site-packages/flask/app.py", line 2091, in __call__
    return self.wsgi_app(environ, start_response)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tholub/git/tysonholub/vcrpy/.tox/py311-httpx/lib/python3.11/site-packages/flask/app.py", line 2080, in wsgi_app
    return response(environ, start_response)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tholub/git/tysonholub/vcrpy/.tox/py311-httpx/lib/python3.11/site-packages/werkzeug/wrappers/response.py", line 632, in __call__
    start_response(status, headers)
  File "/home/tholub/.pyenv/versions/3.11.6/lib/python3.11/wsgiref/handlers.py", line 248, in start_response
    assert not is_hop_by_hop(name),\
AssertionError: Hop-by-hop header, 'Transfer-Encoding: chunked', not allowed
127.0.0.1 - - [10/Jan/2024 10:57:01] "GET /stream-bytes/512 HTTP/1.1" 500 59
```

This issue came to my attention attempting to record requests against openai (whose python client uses httpx). With this change vcrpy is able to record openai responses