### PR TITLE
Fix HTTPS proxy handling

### DIFF
--- a/tests/integration/test_proxy.py
+++ b/tests/integration/test_proxy.py
@@ -85,8 +85,6 @@ def test_use_proxy(tmpdir, httpbin, proxy_server):
     with vcr.use_cassette(str(tmpdir.join("proxy.yaml")), mode="none") as cassette:
         cassette_response = requests.get(httpbin.url, proxies={"http": proxy_server})
 
-    for key in set(cassette_response.headers.keys()) & set(response.headers.keys()):
-        assert cassette_response.headers[key] == response.headers[key]
     assert cassette_response.headers == response.headers
     assert cassette.play_count == 1
 
@@ -102,8 +100,6 @@ def test_use_https_proxy(tmpdir, httpbin_secure, proxy_server):
             proxies={"https": proxy_server},
         )
 
-    for key in set(cassette_response.headers.keys()) & set(response.headers.keys()):
-        assert cassette_response.headers[key] == response.headers[key]
     assert cassette_response.headers == response.headers
     assert cassette.play_count == 1
 

--- a/tests/integration/test_proxy.py
+++ b/tests/integration/test_proxy.py
@@ -82,7 +82,7 @@ def test_use_proxy(tmpdir, httpbin, proxy_server):
     with vcr.use_cassette(str(tmpdir.join("proxy.yaml"))):
         response = requests.get(httpbin.url, proxies={"http": proxy_server})
 
-    with vcr.use_cassette(str(tmpdir.join("proxy.yaml")), mode="once") as cassette:
+    with vcr.use_cassette(str(tmpdir.join("proxy.yaml")), mode="none") as cassette:
         cassette_response = requests.get(httpbin.url, proxies={"http": proxy_server})
 
     for key in set(cassette_response.headers.keys()) & set(response.headers.keys()):
@@ -96,7 +96,7 @@ def test_use_https_proxy(tmpdir, httpbin_secure, proxy_server):
     with vcr.use_cassette(str(tmpdir.join("proxy.yaml"))):
         response = requests.get(httpbin_secure.url, proxies={"https": proxy_server})
 
-    with vcr.use_cassette(str(tmpdir.join("proxy.yaml")), mode="once") as cassette:
+    with vcr.use_cassette(str(tmpdir.join("proxy.yaml")), mode="none") as cassette:
         cassette_response = requests.get(
             httpbin_secure.url,
             proxies={"https": proxy_server},

--- a/tests/integration/test_proxy.py
+++ b/tests/integration/test_proxy.py
@@ -1,5 +1,6 @@
 """Test using a proxy."""
 
+import asyncio
 import http.server
 import socketserver
 import threading
@@ -36,6 +37,35 @@ class Proxy(http.server.SimpleHTTPRequestHandler):
         self.end_headers()
         self.copyfile(upstream_response, self.wfile)
 
+    def do_CONNECT(self):
+        host, port = self.path.split(":")
+
+        asyncio.run(self._tunnel(host, port, self.connection))
+
+    async def _tunnel(self, host, port, client_sock):
+        target_r, target_w = await asyncio.open_connection(host=host, port=port)
+
+        self.send_response(http.HTTPStatus.OK)
+        self.end_headers()
+
+        source_r, source_w = await asyncio.open_connection(sock=client_sock)
+
+        async def channel(reader, writer):
+            while True:
+                data = await reader.read(1024)
+                if not data:
+                    break
+                writer.write(data)
+                await writer.drain()
+
+            writer.close()
+            await writer.wait_closed()
+
+        await asyncio.gather(
+            channel(target_r, source_w),
+            channel(source_r, target_w),
+        )
+
 
 @pytest.fixture(scope="session")
 def proxy_server():
@@ -59,3 +89,23 @@ def test_use_proxy(tmpdir, httpbin, proxy_server):
         assert cassette_response.headers[key] == response.headers[key]
     assert cassette_response.headers == response.headers
     assert cassette.play_count == 1
+
+
+def test_use_https_proxy(tmpdir, httpbin_secure, proxy_server):
+    """Ensure that it works with an HTTPS proxy."""
+    with vcr.use_cassette(str(tmpdir.join("proxy.yaml"))):
+        response = requests.get(httpbin_secure.url, proxies={"https": proxy_server})
+
+    with vcr.use_cassette(str(tmpdir.join("proxy.yaml")), mode="once") as cassette:
+        cassette_response = requests.get(
+            httpbin_secure.url,
+            proxies={"https": proxy_server},
+        )
+
+    for key in set(cassette_response.headers.keys()) & set(response.headers.keys()):
+        assert cassette_response.headers[key] == response.headers[key]
+    assert cassette_response.headers == response.headers
+    assert cassette.play_count == 1
+
+    # The cassette URL points to httpbin, not the proxy
+    assert cassette.requests[0].url == httpbin_secure.url + "/"


### PR DESCRIPTION
When HTTPS requests were made through a proxy, the proxy host name and port ended up in the cassette URLs.

In this PR, I extend the `Proxy` fixture to handle the `CONNECT` method, reproduce the bug and fix it.