### PR TITLE
remove utcfromtimestamp DeprecationWarning ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,7 @@ addopts = [
     "--strict-markers",
 ]
 markers = ["online"]
-filterwarnings = [
-    "error",
-    '''ignore:datetime\.datetime\.utcfromtimestamp\(\) is deprecated and scheduled for removal in a future version.*:DeprecationWarning''',
-]
+filterwarnings = ["error"]
 
 [tool.ruff]
 select = [


### PR DESCRIPTION
Tornado doesn't call this anymore

We used to test on tornado4 and latest so this was a problem. It might be worth dropping support for old tornado versions