### PR TITLE
Improve test compatibility with legacy httpbin index

### DIFF
--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -39,7 +39,7 @@ def test_basic_json_use(tmpdir, httpbin):
     test_fixture = str(tmpdir.join("synopsis.json"))
     with vcr.use_cassette(test_fixture, serializer="json"):
         response = urlopen(httpbin.url).read()
-        assert b"A simple HTTP Request &amp; Response Service." in response
+        assert b"HTTP Request &amp; Response Service" in response
 
 
 def test_patched_content(tmpdir, httpbin):

--- a/tests/integration/test_register_persister.py
+++ b/tests/integration/test_register_persister.py
@@ -66,7 +66,7 @@ def test_load_cassette_with_custom_persister(tmpdir, httpbin):
 
     with my_vcr.use_cassette(test_fixture, serializer="json"):
         response = urlopen(httpbin.url).read()
-        assert b"A simple HTTP Request &amp; Response Service." in response
+        assert b"HTTP Request &amp; Response Service" in response
 
 
 def test_load_cassette_persister_exception_handling(tmpdir, httpbin):


### PR DESCRIPTION
Make the tests slightly more flexible to match both the flasgger-based and legacy httpbin index.  This is needed for compatibility with https://github.com/psf/httpbin/pull/44 when flasgger is not installed (e.g. on architectures that are not supported by Rust).