### PR TITLE
Remove pypy constraint for urllib3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,8 +35,6 @@ jobs:
             urllib3-requirement: "urllib3>=2"
           - python-version: "pypy-3.9"
             urllib3-requirement: "urllib3>=2"
-          - python-version: "pypy-3.10"
-            urllib3-requirement: "urllib3>=2"
 
     steps:
       - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -47,14 +47,12 @@ install_requires = [
     "wrapt",
     "yarl",
     # Support for urllib3 >=2 needs CPython >=3.10
-    # so we need to block urllib3 >=2 for Python <3.10 and PyPy for now.
+    # so we need to block urllib3 >=2 for Python <3.10 for now.
     # Note that vcrpy would work fine without any urllib3 around,
     # so this block and the dependency can be dropped at some point
     # in the future. For more Details:
     # https://github.com/kevin1024/vcrpy/pull/699#issuecomment-1551439663
     "urllib3 <2; python_version <'3.10'",
-    # https://github.com/kevin1024/vcrpy/pull/775#issuecomment-1847849962
-    "urllib3 <2; platform_python_implementation =='PyPy'",
 ]
 
 extras_require = {


### PR DESCRIPTION
I'm not certain whether this is a bug in Poetry or with the marker in setup.py.

Context: 

* https://github.com/kevin1024/vcrpy/pull/787#issuecomment-1954927557
* https://github.com/python-poetry/poetry/issues/8996

A `platform_python_implementation` is specified as `PyPy` for a `urllib3 <2` constraint: https://github.com/kevin1024/vcrpy/blob/master/setup.py#L57

But in essence, if you depend on `urllib3 >= 2` and use CPython + Poetry, you can't install vcrpy.

See sample poetry-compatible `pyproject.toml` 

```toml
[tool.poetry]
name = "benny"
version = "0.1.0"
description = ""
authors = ["Me <hi@localhost>"]
readme = "README.md"

[tool.poetry.dependencies]
python = ">=3.10"
urllib3 = ">=2"
vcrpy = ">=6.0.0"

[build-system]
requires = ["poetry-core"]
build-backend = "poetry.core.masonry.api"
```

When trying to install this with `poetry`:

```bash
$ poetry lock 
Updating dependencies
Resolving dependencies... (0.0s)

Because no versions of vcrpy match >6.0.0,<6.0.1 || >6.0.1
 and vcrpy (6.0.0) depends on urllib3 (<2), vcrpy (>=6.0.0,<6.0.1 || >6.0.1) requires urllib3 (<2).
And because vcrpy (6.0.1) depends on urllib3 (<2), vcrpy (>=6.0.0) requires urllib3 (<2).
So, because benny depends on both urllib3 (>=2) and vcrpy (>=6.0.0), version solving failed.
```

So I'm thinking either the `platform_python_implementation =='PyPy'"` marker is incorrect or Poetry isn't handling it as it should.