### PR TITLE
Permit urllib3 >=2 for non-PyPy Python >=3.10 in order to help users of Poetry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,9 @@ install_requires = [
     "urllib3 <2; python_version <'3.10'",
     # https://github.com/kevin1024/vcrpy/pull/775#issuecomment-1847849962
     "urllib3 <2; platform_python_implementation =='PyPy'",
+    # Workaround for Poetry with CPython >= 3.10, problem description at:
+    # https://github.com/kevin1024/vcrpy/pull/826
+    "urllib3; platform_python_implementation !='PyPy' and python_version >='3.10'",
 ]
 
 extras_require = {


### PR DESCRIPTION
Poetry makes platform indepdent lock files,
so the PyPy marker is there even when using
CPython >= 3.10.

Add a third constraint that permits any urllib3
version when using Python >=3.10 and some
other implementation than PyPy.
