### PR TITLE
Stubs: Mock httpx.Reponse.elapsed with a constant

### DIFF
--- a/vcr/stubs/httpx_stubs.py
+++ b/vcr/stubs/httpx_stubs.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import timedelta
 import functools
 import inspect
 import logging
@@ -100,6 +101,7 @@ def _from_serialized_response(request, serialized_response, history=None):
         history=history or [],
         extensions=extensions,
     )
+    response.elapsed = timedelta(seconds=1)
 
     return response
 


### PR DESCRIPTION
This is a naive way of working around the issue where `httpx.Response.elapsed` property is unavailable in tests that use vcrpy
because the httpx responses built from serialized data by vcrpy currently lack the `elapsed` property.

Relates to issue #600.