### PR TITLE
Fix package install: remove use of deprecated setuptools.command.test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ import re
 import sys
 
 from setuptools import find_packages, setup
-from setuptools.command.test import test as TestCommand
 
 long_description = open("README.rst").read()
 here = os.path.abspath(os.path.dirname(__file__))
@@ -26,20 +25,6 @@ def find_version(*file_paths):
         return version_match.group(1)
 
     raise RuntimeError("Unable to find version string.")
-
-
-class PyTest(TestCommand):
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-
-        errno = pytest.main(self.test_args)
-        sys.exit(errno)
 
 
 install_requires = [

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 import codecs
 import os
 import re
-import sys
 
 from setuptools import find_packages, setup
 


### PR DESCRIPTION
Fixes #855 , fixes #854

At present the package install fails in typical conditions, as it is incompatible with the latest setuptools. The failure can be reproduced with:

```bash
pip wheel --no-cache-dir --use-pep517 "vcrpy (==6.0.1)"
```

This PR removes the used of deprecated setuptools modules, which has led to the package build breaking when installed in isolated environments.

Once this issue is fixed it would be useful to make a swift patch release, as it appears this issue is having quite a large affect on the wider python ecosystem:
https://github.com/pypa/setuptools/issues/4519