### PR TITLE
Fix ruff configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,10 @@ filterwarnings = [
 ]
 
 [tool.ruff]
+line-length = 110
+target-version = "py39"
+
+[tool.ruff.lint]
 select = [
     "B",   # flake8-bugbear
     "C4",  # flake8-comprehensions
@@ -29,8 +33,6 @@ select = [
     "UP",  # pyupgrade
     "W",   # pycodestyle warning
 ]
-line-length = 110
-target-version = "py39"
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["vcr"]


### PR DESCRIPTION
`select` and `isort` must be in `.lint` section.


```bash
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'select' -> 'lint.select'
  - 'isort' -> 'lint.isort'
```