### PR TITLE
Fixed missing `version_string` attribute when used with urllib3>=2.3.0

### DIFF
--- a/vcr/stubs/__init__.py
+++ b/vcr/stubs/__init__.py
@@ -66,6 +66,7 @@ class VCRHTTPResponse(HTTPResponse):
         self.reason = recorded_response["status"]["message"]
         self.status = self.code = recorded_response["status"]["code"]
         self.version = None
+        self.version_string = None
         self._content = BytesIO(self.recorded_response["body"]["string"])
         self._closed = False
         self._original_response = self  # for requests.session.Session cookie extraction


### PR DESCRIPTION
urllib3 in v2.3.0 introduced attribute `version_string` (https://github.com/urllib3/urllib3/pull/3316/files). This attribute  is missing in `VCRHTTPResponse` which causes errors like AttributeError: 'VCRHTTPResponse' object has no attribute 'version_string'

This fixes https://github.com/kevin1024/vcrpy/issues/888