### PR TITLE
Fix: support docker-py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,8 @@ extras_require = {
         "pytest-cov",
         "pytest-httpbin",
         "pytest",
+        "pytest-timeout",
+        "docker",
         "requests>=2.22.0",
         "tornado",
         "urllib3",

--- a/tests/integration/test_docker.py
+++ b/tests/integration/test_docker.py
@@ -1,0 +1,11 @@
+"""Integration tests with docker"""
+
+import pytest
+import docker
+
+import vcr
+
+@pytest.mark.timeout(3)
+def test_docker(tmpdir, timeout=-3):
+    with vcr.use_cassette(str(tmpdir.join("docker.yaml"))):
+        client = docker.from_env()

--- a/vcr/stubs/docker_stubs.py
+++ b/vcr/stubs/docker_stubs.py
@@ -1,0 +1,11 @@
+"""Stubs for docker"""
+
+from docker.transport.unixconn import UnixHTTPConnection
+from ..stubs import VCRHTTPConnection
+
+# docker defines its own UnixHTTPConnection classes. It includes some polyfills
+# for newer features missing in older pythons.
+
+
+class VCRRequestsUnixHTTPConnection(VCRHTTPConnection, UnixHTTPConnection):
+    _baseclass = UnixHTTPConnection


### PR DESCRIPTION
Hello, 
This commit addresses issue #519. There are several things to discuss.

1. I copied and modified the code currently for `urllib3`. I thought this approach is cleaner than adding the code directly for `urllib3`, but if there's a better alternative, please let me know.

2. The tests are very limited. At the moment, they only ensure that Docker does not fall into an infinite loop.

3. As for Docker, there's actually no strong reason to replay it using `vcrpy`. Since the behavior can vary depending on the local environment, replaying it doesn’t seem particularly meaningful. For example, currently I’ve been ignoring cases from Docker using the `ignore_localhost` option. However, I’m unsure whether it would be better to enforce this approach for others.

Let me know your thoughts!