### PR TITLE
fix: usage of io-like interface with VCR.py

### DIFF
--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -1,3 +1,4 @@
+import io
 import logging
 import ssl
 import urllib.parse
@@ -466,3 +467,20 @@ def test_filter_query_parameters(tmpdir, httpbin):
         cassette_content = f.read()
         assert "password" not in cassette_content
         assert "secret" not in cassette_content
+
+
+@pytest.mark.online
+@pytest.mark.asyncio
+def test_use_cassette_with_io(tmpdir, caplog, httpbin):
+    url = httpbin.url + "/post"
+
+    # test without cassettes
+    data = io.BytesIO(b"hello")
+    _, response_json = request("POST", url, output="json", data=data)
+    assert response_json["data"] == "hello"
+
+    # test with cassettes
+    data = io.BytesIO(b"hello")
+    with vcr.use_cassette(str(tmpdir.join("post.yaml"))):
+        _, response_json = request("POST", url, output="json", data=data)
+        assert response_json["data"] == "hello"

--- a/vcr/request.py
+++ b/vcr/request.py
@@ -19,7 +19,12 @@ class Request:
         self._was_file = hasattr(body, "read")
         self._was_iter = _is_nonsequence_iterator(body)
         if self._was_file:
-            self.body = body.read()
+            if hasattr(body, "tell"):
+                tell = body.tell()
+                self.body = body.read()
+                body.seek(tell)
+            else:
+                self.body = body.read()
         elif self._was_iter:
             self.body = list(body)
         else:


### PR DESCRIPTION
This pull request aims to resolve an issue with using VCR.py in conjunction with io-like data.
Let's have a look at this example:

```python
@vcr.use_cassette("issue_vcr_aiohttp.yaml")
def test():
    test = io.BytesIO(b"hello")
    async with aiohttp.ClientSession() as session:
        async with session.post("https://httpbin.org/post", data=test, json=None) as response:
            ret = await response.json()
            assert ret["data"] == "hello"
```

It will trigger the assert, because the body received by aiohttp will be empty.
When using cassette and building Request, the [body is read()](https://github.com/kevin1024/vcrpy/blob/master/vcr/request.py#L22) and later usage of body by aiohttp won't work.
