### PR TITLE
fix(httpx): don't save response if filtered to None

### DIFF
--- a/vcr/stubs/httpx_stubs.py
+++ b/vcr/stubs/httpx_stubs.py
@@ -136,9 +136,7 @@ async def _record_responses(cassette, vcr_request, real_response, aread):
         # final redirect value
         vcr_request = _make_vcr_request(real_response.request)
 
-    should_save_response = cassette._before_record_request(vcr_request) is not None
-    if should_save_response:
-        cassette.append(vcr_request, await _to_serialized_response(real_response, aread))
+    cassette.append(vcr_request, await _to_serialized_response(real_response, aread))
     return real_response
 
 

--- a/vcr/stubs/httpx_stubs.py
+++ b/vcr/stubs/httpx_stubs.py
@@ -174,12 +174,12 @@ def _run_async_function(sync_func, *args, **kwargs):
     - No event loop exists yet.
     """
     try:
-        asyncio.get_running_loop()
+        loop = asyncio.get_running_loop()
     except RuntimeError:
         return asyncio.run(sync_func(*args, **kwargs))
     else:
         # If inside a running loop, create a task and wait for it
-        return asyncio.ensure_future(sync_func(*args, **kwargs))
+        return asyncio.run_coroutine_threadsafe(sync_func(*args, **kwargs), loop)
 
 
 def _sync_vcr_send(cassette, real_send, *args, **kwargs):

--- a/vcr/stubs/httpx_stubs.py
+++ b/vcr/stubs/httpx_stubs.py
@@ -136,7 +136,9 @@ async def _record_responses(cassette, vcr_request, real_response, aread):
         # final redirect value
         vcr_request = _make_vcr_request(real_response.request)
 
-    cassette.append(vcr_request, await _to_serialized_response(real_response, aread))
+    should_save_response = cassette._before_record_request(vcr_request) is not None
+    if should_save_response:
+        cassette.append(vcr_request, await _to_serialized_response(real_response, aread))
     return real_response
 
 


### PR DESCRIPTION
VCR py fails to record response made by starlette (and FastAPI as well) `TestClient` #628.
It seems like the problem hides [in this assert](https://github.com/alekseik1/vcrpy/blob/master/vcr/stubs/httpx_stubs.py#L41) that is triggered by [this func call](https://github.com/alekseik1/vcrpy/blob/master/vcr/stubs/httpx_stubs.py#L139).

I took a quick look and it looks like we're trying to record response to `cassete` object here.
But at the same time, [here](https://github.com/alekseik1/vcrpy/blob/master/vcr/stubs/httpx_stubs.py#L119) we see that whenever filters render `response` to None, a real request is always performed. So, why should we record real response if we don't use it anyway? I made a small check with `should_save_response` variable that runs same filters and skips recording if it will never be replayed.

There's one catch though. Image following scenario:
1. User sets `ignore_hosts=["some.real.host.org"]`, runs tests and gets his cassettes.
2. Neither of cassettes contains requests to "some.real.host.org" since we skipped writing them (by `should_save_response` var).
3. Now, user decides to set `ignore_hosts=[]` and rerun his tests.
4. His cassettes are no longer valid because of a missing request to "some.real.host.org". Such behavior is introduced by this PR.

Does it look sensible?