### PR TITLE
Import iscoroutinefunction() from inspect rather than asyncio

### DIFF
--- a/vcr/cassette.py
+++ b/vcr/cassette.py
@@ -3,7 +3,7 @@ import contextlib
 import copy
 import inspect
 import logging
-from asyncio import iscoroutinefunction
+from inspect import iscoroutinefunction
 
 import wrapt
 


### PR DESCRIPTION
The asyncio function is deprecated starting from Python 3.14 and will be removed from Python 3.16.

This has been discovered during the early testing of vcrpy in Fedora Linux with Python 3.14 alphas.
inspect.iscoroutinefunction() exists since Python 3.5, hence this should pose no compatibility risks.

The example traceback from tests:
```
______________________ test_use_cassette_generator_return ______________________

    def test_use_cassette_generator_return():
        ret_val = object()
    
        vcr = VCR()
    
        @vcr.use_cassette("test")
        def gen():
            return ret_val
            yield
    
        with pytest.raises(StopIteration) as exc_info:
>           next(gen())

tests/unit/test_vcr.py:388: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../BUILDROOT/usr/lib/python3.14/site-packages/vcr/cassette.py:107: in __call__
    return type(self)(self.cls, args_getter)._execute_function(function, args, kwargs)
../BUILDROOT/usr/lib/python3.14/site-packages/vcr/cassette.py:116: in _execute_function
    if iscoroutinefunction(function):
/usr/lib64/python3.14/asyncio/coroutines.py:23: in iscoroutinefunction
    warnings._deprecated("asyncio.iscoroutinefunction",
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

name = 'asyncio.iscoroutinefunction'
message = '{name!r} is deprecated and slated for removal in Python {remove}; use inspect.iscoroutinefunction() instead'

    def _deprecated(name, message=_DEPRECATED_MSG, *, remove, _version=sys.version_info):
        """Warn that *name* is deprecated or should be removed.
    
        RuntimeError is raised if *remove* specifies a major/minor tuple older than
        the current Python version or the same version but past the alpha.
    
        The *message* argument is formatted with *name* and *remove* as a Python
        version tuple (e.g. (3, 11)).
    
        """
        remove_formatted = f"{remove[0]}.{remove[1]}"
        if (_version[:2] > remove) or (_version[:2] == remove and _version[3] != "alpha"):
            msg = f"{name!r} was slated for removal after Python {remove_formatted} alpha"
            raise RuntimeError(msg)
        else:
            msg = message.format(name=name, remove=remove_formatted)
>           warn(msg, DeprecationWarning, stacklevel=3)
E           DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
```