### PR TITLE
fix: don't record message if filtered

### DIFF
--- a/vcr/stubs/httpx_stubs.py
+++ b/vcr/stubs/httpx_stubs.py
@@ -127,6 +127,8 @@ def _shared_vcr_send(cassette, real_send, *args, **kwargs):
 
 
 async def _record_responses(cassette, vcr_request, real_response, aread):
+    if not cassette.filter_request(vcr_request):
+        return real_response
     for past_real_response in real_response.history:
         past_vcr_request = _make_vcr_request(past_real_response.request)
         cassette.append(past_vcr_request, await _to_serialized_response(past_real_response, aread))


### PR DESCRIPTION
From `docs/advanced.rst`:
> Requests that are ignored by VCR will not be saved in a cassette, nor played back from a cassette. VCR will completely ignore those requests as if it didn't notice them at all, and they will continue to hit the server as if VCR were not there.

Which means it is safe to completely ignore these requests when recording responses. 

Why this matters? Because `assert not hasattr(resp, "_decoder")` fails in `_to_serialized_response` func, which breaks `vcr` for Starlette TestClient, see #628.

Fixes #628.