### PR TITLE
fix(aiohttp): Record error responses when raise_for_status is used

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,9 @@ Changelog
 
 All help in providing PRs to close out bug issues is appreciated. Even if that is providing a repo that fully replicates issues. We have very generous contributors that have added these to bug issues which meant another contributor picked up the bug and closed it out.
 
+-  8.2.2
+    - Fix aiohttp not recording error responses when ``raise_for_status`` is used - thanks @andrescollares
+
 -  8.2.1
     - SECURITY: Load cassettes with a safe YAML loader, preventing arbitrary code execution when a cassette from an untrusted source is loaded (GHSA-rpj2-4hq8-938g) - thanks @RamiAltai and @EQSTLab
     - Validate ``record_mode`` and raise a clear error on an invalid value (#208)

--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -515,3 +515,103 @@ def test_use_cassette_with_io(tmpdir, caplog, httpbin):
     with vcr.use_cassette(str(tmpdir.join("post.yaml"))):
         _, response_json = request("POST", url, output="json", data=data)
         assert response_json["data"] == "hello"
+
+
+def test_raise_for_status_enabled_client_session(tmpdir, httpbin):
+    async def run(loop):
+        url = httpbin + "/status/404"
+        path = str(tmpdir.join("raise_for_status.yaml"))
+
+        with vcr.use_cassette(path, record_mode=vcr.mode.ALL) as cassette:
+            async with aiohttp.ClientSession(loop=loop, raise_for_status=True) as session:
+                with pytest.raises(aiohttp.ClientResponseError) as exc_info:
+                    await session.get(url)
+                assert exc_info.value.status == 404
+                assert cassette.play_count == 0
+
+        with vcr.use_cassette(path, record_mode=vcr.mode.NONE) as cassette:
+            async with aiohttp.ClientSession(loop=loop, raise_for_status=True) as session:
+                with pytest.raises(aiohttp.ClientResponseError) as exc_info:
+                    await session.get(url)
+                assert exc_info.value.status == 404
+                assert cassette.play_count == 1
+
+    run_in_loop(run)
+
+
+def test_raise_for_status_custom_client_session(tmpdir, httpbin):
+    async def run(loop):
+        url = httpbin + "/status/404"
+        path = str(tmpdir.join("custom_raise_for_status.yaml"))
+
+        async def custom_raise_for_status(response):
+            if response.status == 404:
+                raise aiohttp.ClientResponseError(
+                    response.request_info,
+                    response.history,
+                    status=response.status,
+                    message="Custom error",
+                )
+
+        with vcr.use_cassette(path, record_mode=vcr.mode.ALL) as cassette:
+            async with aiohttp.ClientSession(loop=loop, raise_for_status=custom_raise_for_status) as session:
+                with pytest.raises(aiohttp.ClientResponseError) as exc_info:
+                    await session.get(url)
+                assert exc_info.value.status == 404
+                assert exc_info.value.message == "Custom error"
+                assert cassette.play_count == 0
+
+        with vcr.use_cassette(path, record_mode=vcr.mode.NONE) as cassette:
+            async with aiohttp.ClientSession(loop=loop, raise_for_status=custom_raise_for_status) as session:
+                with pytest.raises(aiohttp.ClientResponseError) as exc_info:
+                    await session.get(url)
+                assert exc_info.value.status == 404
+                assert exc_info.value.message == "Custom error"
+                assert cassette.play_count == 1
+
+    run_in_loop(run)
+
+
+def test_raise_for_status_enabled_request(tmpdir, httpbin):
+    url = httpbin + "/status/404"
+    path = str(tmpdir.join("raise_for_status.yaml"))
+
+    with vcr.use_cassette(path, record_mode=vcr.mode.ALL) as cassette:
+        with pytest.raises(aiohttp.ClientResponseError) as exc_info:
+            get(url, raise_for_status=True)
+        assert exc_info.value.status == 404
+        assert cassette.play_count == 0
+
+    with vcr.use_cassette(path, record_mode=vcr.mode.NONE) as cassette:
+        with pytest.raises(aiohttp.ClientResponseError) as exc_info:
+            get(url, raise_for_status=True)
+        assert exc_info.value.status == 404
+        assert cassette.play_count == 1
+
+
+def test_raise_for_status_custom_request(tmpdir, httpbin):
+    url = httpbin + "/status/404"
+    path = str(tmpdir.join("custom_raise_for_status.yaml"))
+
+    async def custom_raise_for_status(response):
+        if response.status == 404:
+            raise aiohttp.ClientResponseError(
+                response.request_info,
+                response.history,
+                status=response.status,
+                message="Custom error",
+            )
+
+    with vcr.use_cassette(path, record_mode=vcr.mode.ALL) as cassette:
+        with pytest.raises(aiohttp.ClientResponseError) as exc_info:
+            get(url, raise_for_status=custom_raise_for_status)
+        assert exc_info.value.status == 404
+        assert exc_info.value.message == "Custom error"
+        assert cassette.play_count == 0
+
+    with vcr.use_cassette(path, record_mode=vcr.mode.NONE) as cassette:
+        with pytest.raises(aiohttp.ClientResponseError) as exc_info:
+            get(url, raise_for_status=custom_raise_for_status)
+        assert exc_info.value.status == 404
+        assert exc_info.value.message == "Custom error"
+        assert cassette.play_count == 1

--- a/vcr/stubs/aiohttp_stubs.py
+++ b/vcr/stubs/aiohttp_stubs.py
@@ -326,20 +326,22 @@ def vcr_request(cassette, real_request):
             for redirect in response.history:
                 self._cookie_jar.update_cookies(redirect.cookies, redirect.url)
             self._cookie_jar.update_cookies(response.cookies, response.url)
+        else:
+            if cassette.write_protected and cassette.filter_request(vcr_request):
+                raise CannotOverwriteExistingCassetteException(cassette=cassette, failed_request=vcr_request)
 
-            await _raise_for_status(self, raise_for_status, response)
+            log.info("%s not in cassette, sending to real server", vcr_request)
 
-            return response
-
-        if cassette.write_protected and cassette.filter_request(vcr_request):
-            raise CannotOverwriteExistingCassetteException(cassette=cassette, failed_request=vcr_request)
-
-        log.info("%s not in cassette, sending to real server", vcr_request)
-
-        # Override the raise_for_status parameter to avoid raising an exception before we can record the
-        # response.
-        response = await real_request(self, method, url, **kwargs, raise_for_status=_raise_for_status_stub)
-        await record_responses(cassette, vcr_request, response)
+            # Override the raise_for_status parameter to avoid raising an exception before we can record the
+            # response.
+            response = await real_request(
+                self,
+                method,
+                url,
+                **kwargs,
+                raise_for_status=_raise_for_status_stub,
+            )
+            await record_responses(cassette, vcr_request, response)
 
         await _raise_for_status(self, raise_for_status, response)
 

--- a/vcr/stubs/aiohttp_stubs.py
+++ b/vcr/stubs/aiohttp_stubs.py
@@ -264,6 +264,10 @@ def _build_url_with_params(url_str: str, params: Mapping[str, str | int | float]
     return url.with_query(q)
 
 
+async def _raise_for_status_stub(response: ClientResponse):
+    """Stub for the raise_for_status parameter in aiohttp requests."""
+
+
 def vcr_request(cassette, real_request):
     @functools.wraps(real_request)
     async def new_request(self, method, url, **kwargs):
@@ -302,8 +306,25 @@ def vcr_request(cassette, real_request):
 
         log.info("%s not in cassette, sending to real server", vcr_request)
 
-        response = await real_request(self, method, url, **kwargs)
+        # Override the raise_for_status parameter to avoid raising an exception before we can record the
+        # response.
+        raise_for_status = kwargs.pop("raise_for_status", None)
+
+        response = await real_request(self, method, url, **kwargs, raise_for_status=_raise_for_status_stub)
         await record_responses(cassette, vcr_request, response)
+
+        # This mirrors the raise_for_status logic in
+        # https://github.com/aio-libs/aiohttp/blob/7d56ed37752d220ca3bfd2bc753341d3c47762d8/aiohttp/client.py#L832
+        if raise_for_status is None:
+            raise_for_status = self._raise_for_status
+
+        if raise_for_status is None:
+            pass
+        elif callable(raise_for_status):
+            await raise_for_status(response)
+        elif raise_for_status:
+            response.raise_for_status()
+
         return response
 
     return new_request

--- a/vcr/stubs/aiohttp_stubs.py
+++ b/vcr/stubs/aiohttp_stubs.py
@@ -5,11 +5,19 @@ import functools
 import inspect
 import json
 import logging
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from http.cookies import CookieError, Morsel, SimpleCookie
 from types import SimpleNamespace
 
-from aiohttp import ClientConnectionError, ClientResponse, CookieJar, RequestInfo, hdrs, streams
+from aiohttp import (
+    ClientConnectionError,
+    ClientResponse,
+    ClientSession,
+    CookieJar,
+    RequestInfo,
+    hdrs,
+    streams,
+)
 from aiohttp.helpers import strip_auth_from_url
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict
 from yarl import URL
@@ -268,6 +276,24 @@ async def _raise_for_status_stub(response: ClientResponse):
     """Stub for the raise_for_status parameter in aiohttp requests."""
 
 
+async def _raise_for_status(
+    self: ClientSession,
+    raise_for_status: Callable[[ClientResponse], Awaitable[None]] | bool | None,
+    response: ClientResponse,
+):
+    """This mirrors the raise_for_status logic in
+    https://github.com/aio-libs/aiohttp/blob/7d56ed37752d220ca3bfd2bc753341d3c47762d8/aiohttp/client.py#L832
+    """
+    if raise_for_status is None:
+        raise_for_status = self._raise_for_status
+    if raise_for_status is None:
+        pass
+    elif callable(raise_for_status):
+        await raise_for_status(response)
+    elif raise_for_status:
+        response.raise_for_status()
+
+
 def vcr_request(cassette, real_request):
     @functools.wraps(real_request)
     async def new_request(self, method, url, **kwargs):
@@ -281,6 +307,7 @@ def vcr_request(cassette, real_request):
             raise ValueError("data and json parameters can not be used at the same time")
         params = kwargs.get("params")
         cookies = kwargs.get("cookies")
+        raise_for_status = kwargs.pop("raise_for_status", None)
 
         if auth is not None:
             headers["AUTHORIZATION"] = auth.encode()
@@ -299,6 +326,9 @@ def vcr_request(cassette, real_request):
             for redirect in response.history:
                 self._cookie_jar.update_cookies(redirect.cookies, redirect.url)
             self._cookie_jar.update_cookies(response.cookies, response.url)
+
+            await _raise_for_status(self, raise_for_status, response)
+
             return response
 
         if cassette.write_protected and cassette.filter_request(vcr_request):
@@ -308,22 +338,10 @@ def vcr_request(cassette, real_request):
 
         # Override the raise_for_status parameter to avoid raising an exception before we can record the
         # response.
-        raise_for_status = kwargs.pop("raise_for_status", None)
-
         response = await real_request(self, method, url, **kwargs, raise_for_status=_raise_for_status_stub)
         await record_responses(cassette, vcr_request, response)
 
-        # This mirrors the raise_for_status logic in
-        # https://github.com/aio-libs/aiohttp/blob/7d56ed37752d220ca3bfd2bc753341d3c47762d8/aiohttp/client.py#L832
-        if raise_for_status is None:
-            raise_for_status = self._raise_for_status
-
-        if raise_for_status is None:
-            pass
-        elif callable(raise_for_status):
-            await raise_for_status(response)
-        elif raise_for_status:
-            response.raise_for_status()
+        await _raise_for_status(self, raise_for_status, response)
 
         return response
 


### PR DESCRIPTION
Fixes #635 

Could be a breaking change for those that are using vcrpy with aiohttp and are expecting the library to not record error responses.