### PR TITLE
GitHub Actions: Add Python 3.14 and 3.14t to the testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
           uv pip check
 
       - if: startsWith(matrix.python-version, '3.14')
-        run: uv pip install --system cryptography>=46.0.3
+        run: uv pip install --system cryptography>=46.0.3 Werkzeug==3.1.3
 
       - name: Allow creation of user namespaces (e.g. to the unshare command)
         run: |


### PR DESCRIPTION
https://www.python.org/downloads/release/python-3140/

https://py-free-threading.github.io/porting

https://pypy.org/download.html

Free-threaded Python 3.14t is blocked by:
* [x] ~python-hyper/brotlicffi#205~
* [x] python-hyper/brotlicffi#206 ___REVERTED___
* [ ] A release of https://pypi.org/project/brotlicffi > ~`1.1.0.0`~ `1.2.0.0`
