### PR TITLE
chore: fix async execution when running VCR inside event loop

### DIFF
--- a/vcr/stubs/httpcore_stubs.py
+++ b/vcr/stubs/httpcore_stubs.py
@@ -190,7 +190,6 @@ def _run_async_function(sync_func, *args, **kwargs):
     else:
         # If inside a running loop, run the task in a separated
         # event loop in a new thread.
-        print("Yep, inside loop")
         result = None
         error = None
 
@@ -210,21 +209,17 @@ def _run_async_function(sync_func, *args, **kwargs):
 
 
 def _vcr_handle_request(cassette, real_handle_request, self, real_request):
-    print("Handling synchronous request")
     vcr_request, vcr_response = _run_async_function(
         _vcr_request,
         cassette,
         real_request,
     )
-    print("Got a VCR response:", vcr_response)
 
     if vcr_response:
         return vcr_response
 
     real_response = real_handle_request(self, real_request)
-    print("Got a real response:", real_response)
     _run_async_function(_record_responses, cassette, vcr_request, real_response)
-    print("Recorded the response in the cassette")
 
     return real_response
 


### PR DESCRIPTION
When running VCR inside an already existing event loop, running `asyncio.ensure_future(sync_func(*args, **kwargs))` is not enough to actually execute `sync_func`.

Since the return value is important in this case, there is no straightforward way to call the async method from a sync one that is already running inside the event loop (more or less [this scenario](https://stackoverflow.com/a/78826778)). 

So, this  PR creates a new event loop to run the method, and waits for its result.

In my local tests, this patch seems to solve the issue, but feel free to edit as needed (or point me to anything that needs to be done to merge this).