### PR TITLE
Fix RuntimeError when using httpcore with pytest-asyncio

### DIFF
--- a/vcr/stubs/httpcore_stubs.py
+++ b/vcr/stubs/httpcore_stubs.py
@@ -182,13 +182,22 @@ def _run_async_function(sync_func, *args, **kwargs):
     - An event loop is already running.
     - No event loop exists yet.
     """
+    import concurrent.futures
+
     try:
         asyncio.get_running_loop()
     except RuntimeError:
+        # No event loop running, create one
         return asyncio.run(sync_func(*args, **kwargs))
     else:
-        # If inside a running loop, create a task and wait for it
-        return asyncio.ensure_future(sync_func(*args, **kwargs))
+        # Event loop is already running (e.g., pytest-asyncio)
+        # Run the coroutine in a new thread with its own event loop
+        def run_in_thread():
+            return asyncio.run(sync_func(*args, **kwargs))
+
+        with concurrent.futures.ThreadPoolExecutor() as pool:
+            future = pool.submit(run_in_thread)
+            return future.result()
 
 
 def _vcr_handle_request(cassette, real_handle_request, self, real_request):

--- a/vcr/stubs/httpcore_stubs.py
+++ b/vcr/stubs/httpcore_stubs.py
@@ -3,6 +3,7 @@ import functools
 import logging
 from collections import defaultdict
 from collections.abc import AsyncIterable, Iterable
+from concurrent.futures import ThreadPoolExecutor
 
 from httpcore import Response
 from httpcore._models import ByteStream
@@ -182,8 +183,6 @@ def _run_async_function(sync_func, *args, **kwargs):
     - An event loop is already running.
     - No event loop exists yet.
     """
-    import concurrent.futures
-
     try:
         asyncio.get_running_loop()
     except RuntimeError:
@@ -195,7 +194,7 @@ def _run_async_function(sync_func, *args, **kwargs):
         def run_in_thread():
             return asyncio.run(sync_func(*args, **kwargs))
 
-        with concurrent.futures.ThreadPoolExecutor() as pool:
+        with ThreadPoolExecutor() as pool:
             future = pool.submit(run_in_thread)
             return future.result()
 


### PR DESCRIPTION
Quick claude code PR if it's helpful; just using this locally when I ran into an issue; threadpool feels a bit heavyweight, but it solved my issue.

---

## Problem

When using VCRpy with httpcore and pytest-asyncio (especially with Python 3.13+), the following error occurs:

```
RuntimeError: await wasn't used with future
```

This happens because when pytest-asyncio already has an event loop running, `_run_async_function` uses `asyncio.ensure_future()` which returns a Future object but never awaits it. The synchronous caller then receives a Future instead of the actual result, causing the RuntimeError.

## Solution

This PR fixes the issue by running the async function in a new thread with its own event loop when an event loop is already running. This ensures the synchronous caller receives the actual result instead of a Future object.

The fix uses `concurrent.futures.ThreadPoolExecutor` to:
1. Detect if an event loop is already running
2. If yes, spawn a new thread with its own event loop
3. Run the async function in that thread
4. Block and return the result to the synchronous caller