### PR TITLE
change the check on body

### DIFF
--- a/vcr/serializers/compat.py
+++ b/vcr/serializers/compat.py
@@ -63,9 +63,9 @@ def convert_body_to_unicode(resp):
         body = resp.get("body")
 
         if body is not None:
-            try:
+            if isinstance(body, dict) and "string" in body:
                 body["string"] = _convert_string_to_unicode(body["string"])
-            except (KeyError, TypeError, AttributeError):
+            else:
                 # The thing we were converting either wasn't a dictionary or
                 # didn't have the keys we were expecting.
                 # For example request object has no 'string' key.


### PR DESCRIPTION
To check that body is a dict that contains an string, is probablly better to use instead of a try except clause. This should have the same behaviour, but on some cases improve the typing on the code, because is body is not an instance of a dict, previously `body["string"]` will be marked as failed on typeguard/mypy