### PR TITLE
remove milestone references

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,10 +1,6 @@
 Changelog
 ---------
 
-For a full list of triaged issues, bugs and PRs and what release they are targeted for please see the following link.
-
-`ROADMAP MILESTONES <https://github.com/kevin1024/vcrpy/milestones>`_
-
 All help in providing PRs to close out bug issues is appreciated. Even if that is providing a repo that fully replicates issues. We have very generous contributors that have added these to bug issues which meant another contributor picked up the bug and closed it out.
 
 -  8.1.1

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -5,18 +5,10 @@ Contributing
    :alt: vcr.py logo
    :align: right
 
-🚀 Milestones
---------------
-For anyone interested in the roadmap and projected release milestones please see the following link:
-
-`MILESTONES <https://github.com/kevin1024/vcrpy/milestones>`_
-
-----
-
 🎁 Contributing Issues and PRs
 -------------------------------
 
- - Issues and PRs will get triaged and assigned to the appropriate milestone.
+ - Issues and PRs will get triaged.
  - PRs get priority over issues.
  - The maintainers have limited bandwidth and do so **voluntarily**.
 


### PR DESCRIPTION
Milestones are not used since 2019, and the milestone issue was unpinned on 2022.
In case that there is currently no milestones, it's better to remove the references 
https://github.com/kevin1024/vcrpy/issues/469