### PR TITLE
improve error message on repeated request

### DIFF
--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -52,6 +52,11 @@ from vcr.cassette import Cassette
             "query - assertion failure :\n"
             "failed : query 2\n",
         ),
+        # One matcher suceed, must be already played
+        (
+            [("similar request", ["method", "path", "query"], [])],
+            "Found 1 recorded request(s) matching ('request') but they have already been consumed.\n",
+        ),
     ],
 )
 def test_CannotOverwriteExistingCassetteException_get_message(

--- a/vcr/errors.py
+++ b/vcr/errors.py
@@ -12,21 +12,26 @@ class CannotOverwriteExistingCassetteException(Exception):
         # have match the most with the request.
         best_matches = cassette.find_requests_with_most_matches(failed_request)
         if best_matches:
-            # Build a comprehensible message to put in the exception.
-            best_matches_msg = (
-                f"Found {len(best_matches)} similar requests "
-                f"with {len(best_matches[0][2])} different matcher(s) :\n"
-            )
-
-            for idx, best_match in enumerate(best_matches, start=1):
-                request, succeeded_matchers, failed_matchers_assertion_msgs = best_match
-                best_matches_msg += (
-                    f"\n{idx} - ({request!r}).\n"
-                    f"Matchers succeeded : {succeeded_matchers}\n"
-                    "Matchers failed :\n"
+            if best_matches[0][2]:
+                best_matches_msg = (
+                    f"Found {len(best_matches)} similar requests "
+                    f"with {len(best_matches[0][2])} different matcher(s) :\n"
                 )
-                for failed_matcher, assertion_msg in failed_matchers_assertion_msgs:
-                    best_matches_msg += f"{failed_matcher} - assertion failure :\n{assertion_msg}\n"
+
+                for idx, best_match in enumerate(best_matches, start=1):
+                    request, succeeded_matchers, failed_matchers_assertion_msgs = best_match
+                    best_matches_msg += (
+                        f"\n{idx} - ({request!r}).\n"
+                        f"Matchers succeeded : {succeeded_matchers}\n"
+                        "Matchers failed :\n"
+                    )
+                    for failed_matcher, assertion_msg in failed_matchers_assertion_msgs:
+                        best_matches_msg += f"{failed_matcher} - assertion failure :\n{assertion_msg}\n"
+            else:
+                best_matches_msg = (
+                    f"Found {len(best_matches)} recorded request(s) matching ({failed_request!r}) "
+                    f"but they have already been consumed.\n"
+                )
         else:
             best_matches_msg = "No similar requests, that have not been played, found."
         return (


### PR DESCRIPTION
When there is a repeated request and playback is not allowed, the message was:
Found n similar requests with 0 different matcher(s). 
Changed to a les confusing error. Problem was mentioned on
https://github.com/kevin1024/vcrpy/issues/469
https://github.com/kevin1024/vcrpy/issues/516
https://github.com/kevin1024/vcrpy/issues/929