### PR TITLE
Add httpx2 support

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,6 +22,7 @@ The following HTTP libraries are supported:
 -  ``urllib2``
 -  ``urllib3``
 -  ``httpx``
+-  ``httpx2``
 
 Speed
 -----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ tests = [
     "httplib2",
     "httpx",
     "httpx-curl-cffi",
+    "httpx2",
     "pycurl; platform_python_implementation != 'PyPy'",
     "pyreqwest; python_version >= '3.11'",
     "pytest",

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ tests =
     httplib2
     httpx
     httpx-curl-cffi
+    httpx2
     pycurl; platform_python_implementation != 'PyPy'
     pyreqwest; python_version >= '3.11'
     pytest

--- a/tests/integration/test_httpx2.py
+++ b/tests/integration/test_httpx2.py
@@ -1,0 +1,403 @@
+import os
+
+import pytest
+
+import vcr
+
+from ..assertions import assert_is_json_bytes
+
+asyncio = pytest.importorskip("asyncio")
+httpx2 = pytest.importorskip("httpx2")
+
+
+@pytest.fixture(params=["https", "http"])
+def scheme(request):
+    """Fixture that returns both http and https."""
+    return request.param
+
+
+class BaseDoRequest:
+    _client_class = None
+
+    def __init__(self, *args, **kwargs):
+        self._client_args = args
+        self._client_kwargs = kwargs
+        self._client_kwargs["follow_redirects"] = self._client_kwargs.get("follow_redirects", True)
+
+    def _make_client(self):
+        return self._client_class(*self._client_args, **self._client_kwargs)
+
+
+class DoSyncRequest(BaseDoRequest):
+    _client_class = httpx2.Client
+
+    def __enter__(self):
+        self._client = self._make_client()
+        return self
+
+    def __exit__(self, *args):
+        self._client.close()
+        del self._client
+
+    @property
+    def client(self):
+        try:
+            return self._client
+        except AttributeError as e:
+            raise ValueError('To access sync client, use "with do_request() as client"') from e
+
+    def __call__(self, *args, **kwargs):
+        if hasattr(self, "_client"):
+            return self.client.request(*args, **kwargs)
+
+        # Use one-time context and dispose of the client afterwards
+        with self:
+            return self.client.request(*args, **kwargs)
+
+    def stream(self, *args, **kwargs):
+        if hasattr(self, "_client"):
+            with self.client.stream(*args, **kwargs) as response:
+                return b"".join(response.iter_bytes())
+
+        # Use one-time context and dispose of the client afterwards
+        with self, self.client.stream(*args, **kwargs) as response:
+            return b"".join(response.iter_bytes())
+
+
+class DoAsyncRequest(BaseDoRequest):
+    _client_class = httpx2.AsyncClient
+
+    def __enter__(self):
+        # Need to manage both loop and client, because client's implementation
+        # will fail if the loop is closed before the client's end of life.
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        self._client = self._make_client()
+        self._loop.run_until_complete(self._client.__aenter__())
+        return self
+
+    def __exit__(self, *args):
+        try:
+            self._loop.run_until_complete(self._client.__aexit__(*args))
+        finally:
+            del self._client
+            self._loop.close()
+            del self._loop
+
+    @property
+    def client(self):
+        try:
+            return self._client
+        except AttributeError as e:
+            raise ValueError('To access async client, use "with do_request() as client"') from e
+
+    def __call__(self, *args, **kwargs):
+        if hasattr(self, "_loop"):
+            return self._loop.run_until_complete(self.client.request(*args, **kwargs))
+
+        # Use one-time context and dispose of the loop/client afterwards
+        with self:
+            return self._loop.run_until_complete(self.client.request(*args, **kwargs))
+
+    async def _get_stream(self, *args, **kwargs):
+        async with self.client.stream(*args, **kwargs) as response:
+            content = b""
+            async for c in response.aiter_bytes():
+                content += c
+        return content
+
+    def stream(self, *args, **kwargs):
+        if hasattr(self, "_loop"):
+            return self._loop.run_until_complete(self._get_stream(*args, **kwargs))
+
+        # Use one-time context and dispose of the loop/client afterwards
+        with self:
+            return self._loop.run_until_complete(self._get_stream(*args, **kwargs))
+
+
+def pytest_generate_tests(metafunc):
+    if "do_request" in metafunc.fixturenames:
+        metafunc.parametrize("do_request", [DoAsyncRequest, DoSyncRequest])
+
+
+@pytest.fixture
+def yml(tmpdir, request):
+    return str(tmpdir.join(request.function.__name__ + ".yaml"))
+
+
+def test_response_elapsed(tmpdir, httpbin, do_request):
+    url = httpbin.url
+
+    with vcr.use_cassette(str(tmpdir.join("elapsed.yaml"))):
+        response = do_request()("GET", url)
+
+    with vcr.use_cassette(str(tmpdir.join("elapsed.yaml"))):
+        cassette_response = do_request()("GET", url)
+
+        assert response.elapsed
+        assert cassette_response.elapsed
+
+
+def test_status(tmpdir, httpbin, do_request):
+    url = httpbin.url
+
+    with vcr.use_cassette(str(tmpdir.join("status.yaml"))):
+        response = do_request()("GET", url)
+
+    with vcr.use_cassette(str(tmpdir.join("status.yaml"))) as cassette:
+        cassette_response = do_request()("GET", url)
+        assert cassette_response.status_code == response.status_code
+        assert cassette.play_count == 1
+
+
+def test_case_insensitive_headers(tmpdir, httpbin, do_request):
+    url = httpbin.url
+
+    with vcr.use_cassette(str(tmpdir.join("whatever.yaml"))):
+        do_request()("GET", url)
+
+    with vcr.use_cassette(str(tmpdir.join("whatever.yaml"))) as cassette:
+        cassette_response = do_request()("GET", url)
+        assert "Content-Type" in cassette_response.headers
+        assert "content-type" in cassette_response.headers
+        assert cassette.play_count == 1
+
+
+def test_content(tmpdir, httpbin, do_request):
+    url = httpbin.url
+
+    with vcr.use_cassette(str(tmpdir.join("cointent.yaml"))):
+        response = do_request()("GET", url)
+
+    with vcr.use_cassette(str(tmpdir.join("cointent.yaml"))) as cassette:
+        cassette_response = do_request()("GET", url)
+        assert cassette_response.content == response.content
+        assert cassette.play_count == 1
+
+
+def test_json(tmpdir, httpbin, do_request):
+    url = httpbin.url + "/json"
+
+    with vcr.use_cassette(str(tmpdir.join("json.yaml"))):
+        response = do_request()("GET", url)
+
+    with vcr.use_cassette(str(tmpdir.join("json.yaml"))) as cassette:
+        cassette_response = do_request()("GET", url)
+        assert cassette_response.json() == response.json()
+        assert cassette.play_count == 1
+
+
+def test_params_same_url_distinct_params(tmpdir, httpbin, do_request):
+    url = httpbin.url + "/get"
+    headers = {"Content-Type": "application/json"}
+    params = {"a": 1, "b": False, "c": "c"}
+
+    with vcr.use_cassette(str(tmpdir.join("get.yaml"))) as cassette:
+        response = do_request()("GET", url, params=params, headers=headers)
+
+    with vcr.use_cassette(str(tmpdir.join("get.yaml"))) as cassette:
+        cassette_response = do_request()("GET", url, params=params, headers=headers)
+        assert cassette_response.request.url == response.request.url
+        assert cassette_response.json() == response.json()
+        assert cassette.play_count == 1
+
+    params = {"other": "params"}
+    with (
+        vcr.use_cassette(str(tmpdir.join("get.yaml"))) as cassette,
+        pytest.raises(vcr.errors.CannotOverwriteExistingCassetteException),
+    ):
+        do_request()("GET", url, params=params, headers=headers)
+
+
+def test_redirect(httpbin, yml, do_request):
+    url = httpbin.url + "/redirect-to"
+
+    with vcr.use_cassette(yml):
+        response = do_request()("GET", url, params={"url": "./get", "status_code": 302})
+
+    with vcr.use_cassette(yml) as cassette:
+        cassette_response = do_request()("GET", url, params={"url": "./get", "status_code": 302})
+
+        assert cassette_response.status_code == response.status_code
+        assert len(cassette_response.history) == len(response.history)
+        assert len(cassette) == 2
+        assert cassette.play_count == 2
+
+    # Assert that the real response and the cassette response have a similar
+    # looking request_info.
+    assert cassette_response.request.url == response.request.url
+    assert cassette_response.request.method == response.request.method
+    assert cassette_response.request.headers.items() == response.request.headers.items()
+
+
+@pytest.mark.online
+@pytest.mark.parametrize("url", ["https://github.com/kevin1024/vcrpy/issues/" + str(i) for i in range(3, 6)])
+def test_simple_fetching(do_request, yml, url):
+    with vcr.use_cassette(yml):
+        do_request()("GET", url)
+
+    with vcr.use_cassette(yml) as cassette:
+        cassette_response = do_request()("GET", url)
+        assert str(cassette_response.request.url) == url
+        assert cassette.play_count == 1
+
+
+def test_cookies(tmpdir, httpbin, do_request):
+    def client_cookies(client):
+        return list(client.client.cookies)
+
+    def response_cookies(response):
+        return list(response.cookies)
+
+    url = httpbin.url + "/cookies/set"
+    params = {"k1": "v1", "k2": "v2"}
+
+    with do_request(params=params, follow_redirects=False) as client:
+        assert client_cookies(client) == []
+
+        testfile = str(tmpdir.join("cookies.yml"))
+        with vcr.use_cassette(testfile):
+            r1 = client("GET", url)
+
+            assert response_cookies(r1) == ["k1", "k2"]
+
+            r2 = client("GET", url)
+
+            assert response_cookies(r2) == ["k1", "k2"]
+            assert client_cookies(client) == ["k1", "k2"]
+
+    with do_request(params=params, follow_redirects=False) as new_client:
+        assert client_cookies(new_client) == []
+
+        with vcr.use_cassette(testfile) as cassette:
+            cassette_response = new_client("GET", url)
+
+            assert cassette.play_count == 1
+            assert response_cookies(cassette_response) == ["k1", "k2"]
+            assert client_cookies(new_client) == ["k1", "k2"]
+
+
+def test_stream(tmpdir, httpbin, do_request):
+    url = httpbin.url + "/stream-bytes/512"
+    testfile = str(tmpdir.join("stream.yml"))
+
+    with vcr.use_cassette(testfile):
+        response_content = do_request().stream("GET", url)
+        assert len(response_content) == 512
+
+    with vcr.use_cassette(testfile) as cassette:
+        cassette_content = do_request().stream("GET", url)
+        assert cassette_content == response_content
+        assert len(cassette_content) == 512
+        assert cassette.play_count == 1
+
+
+# Regular cassette formats support the status reason,
+# but the old HTTPX cassette format does not.
+@pytest.mark.parametrize(
+    "cassette_name,reason",
+    [
+        ("requests", "great"),
+        ("httpx_old_format", "OK"),
+    ],
+)
+def test_load_cassette_format(do_request, cassette_name, reason):
+    mydir = os.path.dirname(os.path.realpath(__file__))
+    yml = f"{mydir}/cassettes/gzip_{cassette_name}.yaml"
+    url = "https://httpbin.org/gzip"
+
+    with vcr.use_cassette(yml) as cassette:
+        cassette_response = do_request()("GET", url)
+        assert str(cassette_response.request.url) == url
+        assert cassette.play_count == 1
+
+        # Should be able to load up the JSON inside,
+        # regardless whether the content is the gzipped
+        # in the cassette or not.
+        json = cassette_response.json()
+        assert json["method"] == "GET", json
+        assert cassette_response.status_code == 200
+        assert cassette_response.reason_phrase == reason
+
+
+def test_gzip__decode_compressed_response_false(tmpdir, httpbin, do_request):
+    """
+    Ensure that httpx2 is able to automatically decompress the response body.
+    """
+    for _ in range(2):  # one for recording, one for re-playing
+        with vcr.use_cassette(str(tmpdir.join("gzip.yaml"))) as cassette:
+            response = do_request()("GET", httpbin + "/gzip")
+            assert response.headers["content-encoding"] == "gzip"  # i.e. not removed
+            # The content stored in the cassette should be gzipped.
+            assert cassette.responses[0]["body"]["string"][:2] == b"\x1f\x8b"
+            assert_is_json_bytes(response.content)  # i.e. uncompressed bytes
+
+
+def test_gzip__decode_compressed_response_true(do_request, tmpdir, httpbin):
+    url = httpbin + "/gzip"
+
+    expected_response = do_request()("GET", url)
+    expected_content = expected_response.content
+    assert expected_response.headers["content-encoding"] == "gzip"  # self-test
+
+    with vcr.use_cassette(
+        str(tmpdir.join("decode_compressed.yaml")),
+        decode_compressed_response=True,
+    ) as cassette:
+        r = do_request()("GET", url)
+        assert r.headers["content-encoding"] == "gzip"  # i.e. not removed
+        content_length = r.headers["content-length"]
+        assert r.content == expected_content
+
+    # Has the cassette body been decompressed?
+    cassette_response_body = cassette.responses[0]["body"]["string"]
+    assert isinstance(cassette_response_body, str)
+
+    # Content should be JSON.
+    assert cassette_response_body[0:1] == "{"
+
+    with vcr.use_cassette(str(tmpdir.join("decode_compressed.yaml")), decode_compressed_response=True):
+        r = httpx2.get(url)
+        assert "content-encoding" not in r.headers  # i.e. removed
+        assert r.content == expected_content
+
+        # As the content is uncompressed, it should have a bigger
+        # length than the compressed version.
+        assert r.headers["content-length"] > content_length
+
+
+def test_sync_in_async_context(tmpdir, httpbin):
+    async def run():
+        url = httpbin.url
+
+        with vcr.use_cassette(str(tmpdir.join("sync_in_async_context.yaml"))):
+            DoSyncRequest()("GET", url)
+
+        with vcr.use_cassette(str(tmpdir.join("sync_in_async_context.yaml"))) as cassette:
+            DoSyncRequest()("GET", url)
+            assert cassette.play_count == 1
+
+    asyncio.run(run())
+
+
+def test_custom_transports(tmpdir, httpbin):
+    url = httpbin.url
+    transport = httpx2.MockTransport(lambda _: httpx2.Response(200, json={"text": "Hello, world!"}))
+
+    with vcr.use_cassette(str(tmpdir.join("mock_transport.yaml"))):
+        response = DoSyncRequest(transport=transport)("GET", url)
+
+    with vcr.use_cassette(str(tmpdir.join("mock_transport.yaml"))) as cassette:
+        cassette_response = DoSyncRequest(transport=transport)("GET", url)
+
+        assert cassette_response.status_code == response.status_code
+        assert cassette.play_count == 1
+
+
+def test_connection_limits(tmpdir, httpbin, do_request):
+    url = httpbin.url
+    limits = httpx2.Limits(max_connections=1)
+
+    with vcr.use_cassette(str(tmpdir.join("connection_limits.yaml"))), do_request(limits=limits) as client:
+        for _ in range(2):
+            client("GET", url)

--- a/vcr/patch.py
+++ b/vcr/patch.py
@@ -124,6 +124,19 @@ else:
     )
 
 
+try:
+    import httpx2
+except ImportError:  # pragma: no cover
+    pass
+else:
+    _Httpx2HttpTransport_handle_request = httpx2.HTTPTransport.handle_request
+    _Httpx2AsyncHttpTransport_handle_async_request = httpx2.AsyncHTTPTransport.handle_async_request
+    _Httpx2WsgiTransport_handle_request = httpx2.WSGITransport.handle_request
+    _Httpx2AsgiTransport_handle_async_request = httpx2.ASGITransport.handle_async_request
+    _Httpx2MockTransport_handle_request = httpx2.MockTransport.handle_request
+    _Httpx2MockTransport_handle_async_request = httpx2.MockTransport.handle_async_request
+
+
 class CassettePatcherBuilder:
     def _build_patchers_from_mock_triples_decorator(function):
         @functools.wraps(function)
@@ -146,6 +159,7 @@ class CassettePatcherBuilder:
             self._tornado(),
             self._aiohttp(),
             self._httpx(),
+            self._httpx2(),
             self._build_patchers_from_mock_triples(self._cassette.custom_patches),
         )
 
@@ -336,30 +350,33 @@ class CassettePatcherBuilder:
         else:
             from .stubs.httpx_stubs import vcr_handle_async_request, vcr_handle_request
 
-            new_handle_request = vcr_handle_request(self._cassette, _HttpxHttpTransport_handle_request)
+            new_handle_request = vcr_handle_request(self._cassette, _HttpxHttpTransport_handle_request, httpx)
             yield httpx.HTTPTransport, "handle_request", new_handle_request
 
             new_handle_async_request = vcr_handle_async_request(
                 self._cassette,
                 _HttpxAsyncHttpTransport_handle_async_request,
+                httpx,
             )
             yield httpx.AsyncHTTPTransport, "handle_async_request", new_handle_async_request
 
-            new_handle_request = vcr_handle_request(self._cassette, _HttpxWsgiTransport_handle_request)
+            new_handle_request = vcr_handle_request(self._cassette, _HttpxWsgiTransport_handle_request, httpx)
             yield httpx.WSGITransport, "handle_request", new_handle_request
 
             new_handle_async_request = vcr_handle_async_request(
                 self._cassette,
                 _HttpxAsgiTransport_handle_async_request,
+                httpx,
             )
             yield httpx.ASGITransport, "handle_async_request", new_handle_async_request
 
-            new_handle_request = vcr_handle_request(self._cassette, _HttpxMockTransport_handle_request)
+            new_handle_request = vcr_handle_request(self._cassette, _HttpxMockTransport_handle_request, httpx)
             yield httpx.MockTransport, "handle_request", new_handle_request
 
             new_handle_async_request = vcr_handle_async_request(
                 self._cassette,
                 _HttpxMockTransport_handle_async_request,
+                httpx,
             )
             yield httpx.MockTransport, "handle_async_request", new_handle_async_request
 
@@ -370,12 +387,13 @@ class CassettePatcherBuilder:
         else:
             from .stubs.httpx_stubs import vcr_handle_async_request, vcr_handle_request
 
-            new_handle_request = vcr_handle_request(self._cassette, _HttpxCurlTransport_handle_request)
+            new_handle_request = vcr_handle_request(self._cassette, _HttpxCurlTransport_handle_request, httpx)
             yield httpx_curl_cffi.CurlTransport, "handle_request", new_handle_request
 
             new_handle_async_request = vcr_handle_async_request(
                 self._cassette,
                 _HttpxAsyncCurlTransport_handle_async_request,
+                httpx,
             )
             yield httpx_curl_cffi.AsyncCurlTransport, "handle_async_request", new_handle_async_request
 
@@ -389,18 +407,71 @@ class CassettePatcherBuilder:
             new_handle_request = vcr_handle_request(
                 self._cassette,
                 _HttpxSyncPyreqwestTransport_handle_request,
+                httpx,
             )
             yield pyreqwest.compatibility.httpx.SyncHttpxTransport, "handle_request", new_handle_request
 
             new_handle_async_request = vcr_handle_async_request(
                 self._cassette,
                 _HttpxPyreqwestTransport_handle_async_request,
+                httpx,
             )
             yield (
                 pyreqwest.compatibility.httpx.HttpxTransport,
                 "handle_async_request",
                 new_handle_async_request,
             )
+
+    @_build_patchers_from_mock_triples_decorator
+    def _httpx2(self):
+        try:
+            import httpx2
+        except ImportError:  # pragma: no cover
+            pass
+        else:
+            from .stubs.httpx_stubs import vcr_handle_async_request, vcr_handle_request
+
+            new_handle_request = vcr_handle_request(
+                self._cassette,
+                _Httpx2HttpTransport_handle_request,
+                httpx2,
+            )
+            yield httpx2.HTTPTransport, "handle_request", new_handle_request
+
+            new_handle_async_request = vcr_handle_async_request(
+                self._cassette,
+                _Httpx2AsyncHttpTransport_handle_async_request,
+                httpx2,
+            )
+            yield httpx2.AsyncHTTPTransport, "handle_async_request", new_handle_async_request
+
+            new_handle_request = vcr_handle_request(
+                self._cassette,
+                _Httpx2WsgiTransport_handle_request,
+                httpx2,
+            )
+            yield httpx2.WSGITransport, "handle_request", new_handle_request
+
+            new_handle_async_request = vcr_handle_async_request(
+                self._cassette,
+                _Httpx2AsgiTransport_handle_async_request,
+                httpx2,
+            )
+            yield httpx2.ASGITransport, "handle_async_request", new_handle_async_request
+
+            new_handle_request = vcr_handle_request(
+                self._cassette,
+                _Httpx2MockTransport_handle_request,
+                httpx2,
+            )
+            yield httpx2.MockTransport, "handle_request", new_handle_request
+
+            new_handle_async_request = vcr_handle_async_request(
+                self._cassette,
+                _Httpx2MockTransport_handle_async_request,
+                httpx2,
+            )
+            yield httpx2.MockTransport, "handle_async_request", new_handle_async_request
 
     def _urllib3_patchers(self, cpool, conn, stubs):
         http_connection_remover = ConnectionRemover(
@@ -578,6 +649,42 @@ def reset_patchers():
             httpx_curl_cffi.AsyncCurlTransport,
             "handle_async_request",
             _HttpxAsyncCurlTransport_handle_async_request,
+        )
+
+    try:
+        import httpx2
+    except ImportError:  # pragma: no cover
+        pass
+    else:
+        yield mock.patch.object(
+            httpx2.HTTPTransport,
+            "handle_request",
+            _Httpx2HttpTransport_handle_request,
+        )
+        yield mock.patch.object(
+            httpx2.AsyncHTTPTransport,
+            "handle_async_request",
+            _Httpx2AsyncHttpTransport_handle_async_request,
+        )
+        yield mock.patch.object(
+            httpx2.WSGITransport,
+            "handle_request",
+            _Httpx2WsgiTransport_handle_request,
+        )
+        yield mock.patch.object(
+            httpx2.ASGITransport,
+            "handle_async_request",
+            _Httpx2AsgiTransport_handle_async_request,
+        )
+        yield mock.patch.object(
+            httpx2.MockTransport,
+            "handle_request",
+            _Httpx2MockTransport_handle_request,
+        )
+        yield mock.patch.object(
+            httpx2.MockTransport,
+            "handle_async_request",
+            _Httpx2MockTransport_handle_async_request,
         )
 
 

--- a/vcr/stubs/httpx_stubs.py
+++ b/vcr/stubs/httpx_stubs.py
@@ -1,9 +1,15 @@
+"""VCR stubs for httpx transports.
+
+The httpx module to patch against is passed in (``httpx`` or its interoperable
+fork ``httpx2``) rather than imported at module level, so a single stub serves
+both. Only the ``Response`` / ``ByteStream`` classes and the ``request_context``
+helper differ between the two; everything else operates on the duck-typed
+request/response.
+"""
+
 import functools
 import logging
 from collections import defaultdict
-
-from httpx import ByteStream, Response
-from httpx._exceptions import request_context
 
 from vcr.errors import CannotOverwriteExistingCassetteException
 from vcr.filters import decode_response
@@ -43,7 +49,7 @@ def _deserialize_headers(headers):
     return [(name, value) for name, values in headers.items() for value in values]
 
 
-def _deserialize_response(vcr_response):
+def _deserialize_response(vcr_response, httpx):
     # Cassette format generated for HTTPX requests by older versions of
     # vcrpy. We restructure the content to resemble what a regular
     # cassette looks like.
@@ -61,12 +67,12 @@ def _deserialize_response(vcr_response):
     else:
         extensions = {"reason_phrase": vcr_response["status"]["message"].encode("ascii")}
 
-    return Response(
+    return httpx.Response(
         vcr_response["status"]["code"],
         headers=_deserialize_headers(vcr_response["headers"]),
         # Don't use content, because that closes the response,
         # which we do not want as the real response is unclosed
-        stream=ByteStream(vcr_response["body"]["string"]),
+        stream=httpx.ByteStream(vcr_response["body"]["string"]),
         extensions=extensions,
     )
 
@@ -75,11 +81,11 @@ def _make_vcr_request(real_request, real_request_body):
     return VcrRequest(real_request.method, str(real_request.url), real_request_body, real_request.headers)
 
 
-def _vcr_request(cassette, real_request, real_request_body):
+def _vcr_request(cassette, real_request, real_request_body, httpx):
     vcr_request = _make_vcr_request(real_request, real_request_body)
 
     if cassette.can_play_response_for(vcr_request):
-        return vcr_request, _play_responses(cassette, vcr_request)
+        return vcr_request, _play_responses(cassette, vcr_request, httpx)
 
     if cassette.write_protected and cassette.filter_request(vcr_request):
         raise CannotOverwriteExistingCassetteException(cassette=cassette, failed_request=vcr_request)
@@ -93,19 +99,19 @@ def _record_responses(cassette, vcr_request, real_response, real_response_conten
     cassette.append(vcr_request, _serialize_response(real_response, real_response_content))
 
 
-def _play_responses(cassette, vcr_request):
+def _play_responses(cassette, vcr_request, httpx):
     vcr_response = cassette.play_response(vcr_request)
-    real_response = _deserialize_response(vcr_response)
+    real_response = _deserialize_response(vcr_response, httpx)
 
     return real_response
 
 
-async def _vcr_handle_async_request(cassette, real_handle_async_request, self, real_request):
+async def _vcr_handle_async_request(cassette, real_handle_async_request, self, real_request, httpx):
     # Reading the request stream consumes the iterator, so we need to restore it afterwards
     real_request_body = b"".join([part async for part in real_request.stream])
-    real_request.stream = ByteStream(real_request_body)
+    real_request.stream = httpx.ByteStream(real_request_body)
 
-    vcr_request, vcr_response = _vcr_request(cassette, real_request, real_request_body)
+    vcr_request, vcr_response = _vcr_request(cassette, real_request, real_request_body, httpx)
 
     if vcr_response:
         return vcr_response
@@ -114,31 +120,31 @@ async def _vcr_handle_async_request(cassette, real_handle_async_request, self, r
     real_response_content = b"".join([part async for part in real_response.stream])
 
     # Close the original stream so that the connection is released back to the connection pool
-    with request_context(request=real_response._request):
+    with httpx._exceptions.request_context(request=real_response._request):
         await real_response.stream.aclose()
 
     # Reading the response stream consumes the iterator, so we need to restore it
-    real_response.stream = ByteStream(real_response_content)
+    real_response.stream = httpx.ByteStream(real_response_content)
 
     _record_responses(cassette, vcr_request, real_response, real_response_content)
 
     return real_response
 
 
-def vcr_handle_async_request(cassette, real_handle_async_request):
+def vcr_handle_async_request(cassette, real_handle_async_request, httpx):
     @functools.wraps(real_handle_async_request)
     def _inner_handle_async_request(self, real_request):
-        return _vcr_handle_async_request(cassette, real_handle_async_request, self, real_request)
+        return _vcr_handle_async_request(cassette, real_handle_async_request, self, real_request, httpx)
 
     return _inner_handle_async_request
 
 
-def _vcr_handle_request(cassette, real_handle_request, self, real_request):
+def _vcr_handle_request(cassette, real_handle_request, self, real_request, httpx):
     # Reading the request stream consumes the iterator, so we need to restore it afterwards
     real_request_body = b"".join(real_request.stream)
-    real_request.stream = ByteStream(real_request_body)
+    real_request.stream = httpx.ByteStream(real_request_body)
 
-    vcr_request, vcr_response = _vcr_request(cassette, real_request, real_request_body)
+    vcr_request, vcr_response = _vcr_request(cassette, real_request, real_request_body, httpx)
 
     if vcr_response:
         return vcr_response
@@ -147,20 +153,20 @@ def _vcr_handle_request(cassette, real_handle_request, self, real_request):
     real_response_content = b"".join(real_response.stream)
 
     # Close the original stream so that the connection is released back to the connection pool
-    with request_context(request=real_response._request):
+    with httpx._exceptions.request_context(request=real_response._request):
         real_response.stream.close()
 
     # Reading the response stream consumes the iterator, so we need to restore it
-    real_response.stream = ByteStream(real_response_content)
+    real_response.stream = httpx.ByteStream(real_response_content)
 
     _record_responses(cassette, vcr_request, real_response, real_response_content)
 
     return real_response
 
 
-def vcr_handle_request(cassette, real_handle_request):
+def vcr_handle_request(cassette, real_handle_request, httpx):
     @functools.wraps(real_handle_request)
     def _inner_handle_request(self, real_request):
-        return _vcr_handle_request(cassette, real_handle_request, self, real_request)
+        return _vcr_handle_request(cassette, real_handle_request, self, real_request, httpx)
 
     return _inner_handle_request


### PR DESCRIPTION
David's AICA here:

Closes the silent-bypass failure from #990: code using `httpx2` (a fork of `httpx`) bypasses the cassette entirely and hits the live server, with no signal that VCR didn't intercept.

**Rebased onto the new transport-patching design (#972).** Since #972 landed, vcrpy patches **httpx transports** directly (`HTTPTransport`, `AsyncHTTPTransport`, `WSGITransport`, `ASGITransport`, `MockTransport`) rather than httpcore. This PR has been re-targeted accordingly: it now adds `httpx2` support at the same transport layer (the earlier httpcore2 approach is gone — vcrpy no longer touches httpcore).

**No duplicated stub.** Per @seowalex's / @kevin1024's feedback on #990, the two libs share a single stub. `vcr/stubs/httpx_stubs.py` is parameterized by the httpx module to patch against (`httpx` or `httpx2`) — only `Response` / `ByteStream` and the `request_context` helper differ; everything else operates on the duck-typed request/response.

**Changes:**
1. `vcr/stubs/httpx_stubs.py` — drop the top-level `from httpx import ...`; take the httpx module as a parameter so it loads when only `httpx2` is installed and serves both.
2. `vcr/patch.py` — `try: import httpx2` save block; a `_httpx2` patcher mirroring `_httpx`'s core transports (registered in `build()`); a matching `reset_patchers()` block. `_httpx` now passes the `httpx` module into the shared stub (httpx core + `httpx_curl_cffi` + `pyreqwest`, all of which produce httpx objects).
3. `pyproject.toml` / `setup.cfg` — add `httpx2` to the `tests` extra.
4. `tests/integration/test_httpx2.py` — mirrors `test_httpx.py` with `httpx` → `httpx2` (plus a `gzip_httpx2_old_format.yaml` cassette). The `httpx_curl_cffi` / `pyreqwest` alt-transport cases are omitted — those belong to the httpx ecosystem and aren't compatible with `httpx2.Client`; `MockTransport` coverage is kept.
5. `docs/installation.rst` — list `httpx2` as supported.

`pytest tests/integration/test_httpx.py tests/integration/test_httpx2.py` → 72 passed locally; full unit suite (181) green.
