### PR TITLE
Fix aiohttp 3.14 compatibility (`AsyncStreamReaderMixin` removed, `ClientResponse` requires `stream_writer`)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,9 @@ For a full list of triaged issues, bugs and PRs and what release they are target
 
 All help in providing PRs to close out bug issues is appreciated. Even if that is providing a repo that fully replicates issues. We have very generous contributors that have added these to bug issues which meant another contributor picked up the bug and closed it out.
 
+-  8.1.2
+    - Fix aiohttp 3.14 compatibility: ``AsyncStreamReaderMixin`` removed and ``ClientResponse`` now requires ``stream_writer`` (#995) - thanks @dsfaccini
+
 -  8.1.1
     - Fix sync requests in async contexts for HTTPX (#965) - thanks @seowalex
     - CI: bump peter-evans/create-pull-request from 7 to 8 (#969)

--- a/tests/integration/aiohttp_utils.py
+++ b/tests/integration/aiohttp_utils.py
@@ -18,6 +18,8 @@ async def aiohttp_request(loop, method, url, output="text", encoding="utf-8", co
             content = await response.read()
         elif output == "stream":
             content = await response.content.read()
+        elif output == "stream_chunked":
+            content = b"".join([chunk async for chunk in response.content.iter_chunked(1024)])
 
         response_ctx._resp.close()
         await session.close()

--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -137,6 +137,21 @@ def test_stream(tmpdir, httpbin):
         assert cassette.play_count == 1
 
 
+@pytest.mark.online
+def test_stream_chunked(tmpdir, httpbin):
+    # Exercises the async-iteration surface (``content.iter_chunked``) that
+    # ``MockStream`` must keep providing across aiohttp versions.
+    url = httpbin.url
+
+    with vcr.use_cassette(str(tmpdir.join("stream.yaml"))):
+        _, body = get(url, output="raw")  # Do not use stream here, as the stream is exhausted by vcr
+
+    with vcr.use_cassette(str(tmpdir.join("stream.yaml"))) as cassette:
+        _, cassette_body = get(url, output="stream_chunked")
+        assert cassette_body == body
+        assert cassette.play_count == 1
+
+
 POST_DATA = {"key1": "value1", "key2": "value2"}
 
 

--- a/vcr/stubs/aiohttp_stubs.py
+++ b/vcr/stubs/aiohttp_stubs.py
@@ -2,10 +2,12 @@
 
 import asyncio
 import functools
+import inspect
 import json
 import logging
 from collections.abc import Mapping
 from http.cookies import CookieError, Morsel, SimpleCookie
+from types import SimpleNamespace
 
 from aiohttp import ClientConnectionError, ClientResponse, CookieJar, RequestInfo, hdrs, streams
 from aiohttp.helpers import strip_auth_from_url
@@ -17,13 +19,35 @@ from vcr.request import Request
 
 log = logging.getLogger(__name__)
 
+# aiohttp 3.14 made ``stream_writer`` a required ClientResponse argument and,
+# when ``writer`` is None, reads ``stream_writer.output_size``. A replayed
+# response has already been "sent", so a zero-sized writer is accurate. Older
+# aiohttp doesn't accept the argument at all.
+_CLIENT_RESPONSE_PARAMS = inspect.signature(ClientResponse.__init__).parameters
+_CLIENT_RESPONSE_ACCEPTS_STREAM_WRITER = "stream_writer" in _CLIENT_RESPONSE_PARAMS
 
-class MockStream(asyncio.StreamReader, streams.AsyncStreamReaderMixin):
-    pass
+
+class MockStream(asyncio.StreamReader):
+    # aiohttp added the async-iteration helpers below to its response stream via
+    # ``streams.AsyncStreamReaderMixin``, which aiohttp 3.14 removed (folding the
+    # helpers into its own ``StreamReader``). This stub builds on
+    # ``asyncio.StreamReader`` instead, so provide the helpers directly to keep the
+    # streaming surface stable across aiohttp versions.
+    def iter_chunked(self, n):
+        return streams.AsyncStreamIterator(lambda: self.read(n))
+
+    def iter_any(self):
+        return streams.AsyncStreamIterator(self.readany)
+
+    def iter_chunks(self):
+        return streams.ChunkTupleAsyncStreamIterator(self)
 
 
 class MockClientResponse(ClientResponse):
     def __init__(self, method, url, request_info=None):
+        extra = {}
+        if _CLIENT_RESPONSE_ACCEPTS_STREAM_WRITER:
+            extra["stream_writer"] = SimpleNamespace(output_size=0)
         super().__init__(
             method=method,
             url=url,
@@ -34,6 +58,7 @@ class MockClientResponse(ClientResponse):
             traces=None,
             loop=asyncio.get_event_loop(),
             session=None,
+            **extra,
         )
 
     async def json(self, *, encoding="utf-8", loads=json.loads, **kwargs):


### PR DESCRIPTION
## Symptom

Under aiohttp 3.14.0, importing vcrpy's aiohttp stub crashes:

```
AttributeError: module 'aiohttp.streams' has no attribute 'AsyncStreamReaderMixin'
```

and once that's worked around, cassette playback fails with
`TypeError: ClientResponse.__init__() missing 1 required keyword-only argument: 'stream_writer'`.

Fixes #995.

## Root cause

aiohttp 3.14.0 introduced two independent breaking changes to internals that vcrpy's
stub relied on:

1. **`aiohttp.streams.AsyncStreamReaderMixin` was removed** in
   [aio-libs/aiohttp#12357](https://github.com/aio-libs/aiohttp/pull/12357). The symbol
   was internal — never in `aiohttp.streams.__all__`, never documented — so its removal
   isn't treated as a breaking change by aiohttp; the fix belongs here. The mixin only
   provided the async-iteration helpers (`iter_chunked`, `iter_any`, `iter_chunks`) on top
   of `StreamReader`; in 3.14 those were folded directly into `aiohttp.streams.StreamReader`.

2. **`ClientResponse.__init__` now requires a `stream_writer` argument** and, when
   `writer is None`, reads `stream_writer.output_size`.

## Fix

- `MockStream` no longer subclasses the removed mixin. It keeps `asyncio.StreamReader` and
  reimplements just the three helpers the mixin added, using aiohttp's own
  `AsyncStreamIterator` / `ChunkTupleAsyncStreamIterator` (present in both old and new aiohttp).
  `__aiter__`/`read` continue to resolve to `asyncio.StreamReader`, exactly as before.
- `MockClientResponse` passes a zero-sized `stream_writer` stub **only when** the running
  aiohttp's `ClientResponse` accepts that parameter (detected via signature introspection).
  A replayed response has already been "sent", so `output_size = 0` is accurate.

## Backward compatibility

vcrpy declares no aiohttp version bound (it's a lazily-imported test extra), so this must work
on any aiohttp. **No version cap is added.** The `stream_writer` argument is passed only when
present, and the iterator helpers exist in both versions, so the stub imports and plays back
cassettes under aiohttp `< 3.14` and `>= 3.14` alike.

## Verification

- `tests/integration/test_aiohttp.py`: **29 passed** under both aiohttp **3.14.0** and **3.13.5**.
- Added `test_stream_chunked`, which exercises `response.content.iter_chunked(...)` — the
  async-iteration surface that the existing suite never touched and that would otherwise
  silently regress.
- `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
