### PR TITLE
docs: replace Python 2 urllib2 with urllib.request in examples

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -11,10 +11,10 @@ a nice addition. Here's an example:
 .. code:: python
 
     import vcr
-    import urllib2
+    import urllib.request
 
     with vcr.use_cassette('fixtures/vcr_cassettes/synopsis.yaml') as cass:
-        response = urllib2.urlopen('http://www.zombo.com/').read()
+        response = urllib.request.urlopen('http://www.zombo.com/').read()
         # cass should have 1 request inside it
         assert len(cass) == 1
         # the request uri should have been http://www.zombo.com/
@@ -255,7 +255,7 @@ path.
 
     def scrub_login_request(request):
         if request.path == '/login':
-            request.uri, _ =  urllib.splitquery(request.uri)
+            request.uri = request.uri.split('?', 1)[0]
         return request
 
     my_vcr = vcr.VCR(
@@ -384,8 +384,11 @@ VCR.py allows to rewind a cassette in order to replay it inside the same functio
 
 .. code:: python
 
+    import vcr
+    import urllib.request
+
     with vcr.use_cassette('fixtures/vcr_cassettes/synopsis.yaml') as cass:
-        response = urllib2.urlopen('http://www.zombo.com/').read()
+        response = urllib.request.urlopen('http://www.zombo.com/').read()
         assert cass.all_played
         cass.rewind()
         assert not cass.all_played
@@ -401,9 +404,12 @@ the Cassette ``allow_playback_repeats`` option.
 
 .. code:: python
 
+    import vcr
+    import urllib.request
+
     with vcr.use_cassette('fixtures/vcr_cassettes/synopsis.yaml', allow_playback_repeats=True) as cass:
         for x in range(10):
-            response = urllib2.urlopen('http://www.zombo.com/').read()
+            response = urllib.request.urlopen('http://www.zombo.com/').read()
         assert cass.all_played
 
 Discards Cassette on Errors
@@ -417,10 +423,14 @@ If you want to save the cassette only when the test succeeds, set the Cassette
 
 .. code:: python
 
+    import os
+    import urllib.request
+    import vcr
+
     try:
-        my_vcr = VCR(record_on_exception=False)
+        my_vcr = vcr.VCR(record_on_exception=False)
         with my_vcr.use_cassette('fixtures/vcr_cassettes/synopsis.yaml') as cass:
-            response = urllib2.urlopen('http://www.zombo.com/').read()
+            response = urllib.request.urlopen('http://www.zombo.com/').read()
             raise RuntimeError("Oops, something happened")
     except RuntimeError:
         pass

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,9 @@ For a full list of triaged issues, bugs and PRs and what release they are target
 
 All help in providing PRs to close out bug issues is appreciated. Even if that is providing a repo that fully replicates issues. We have very generous contributors that have added these to bug issues which meant another contributor picked up the bug and closed it out.
 
+-  8.1.2 (unreleased)
+    - Fix docs: replace Python 2 ``urllib2`` with ``urllib.request`` in advanced.rst and installation.rst - thanks @TejasAmle
+
 -  8.1.1
     - Fix sync requests in async contexts for HTTPX (#965) - thanks @seowalex
     - CI: bump peter-evans/create-pull-request from 7 to 8 (#969)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,7 +19,7 @@ The following HTTP libraries are supported:
 -  ``httplib2``
 -  ``requests`` (>=2.16.2 versions)
 -  ``tornado.httpclient``
--  ``urllib2``
+-  ``urllib.request``
 -  ``urllib3``
 -  ``httpx``
 -  ``httpcore``


### PR DESCRIPTION
## What

Replace Python 2 `urllib2` references with the Python 3 equivalent `urllib.request` throughout `docs/advanced.rst` and `docs/installation.rst`.

Also fixes `urllib.splitquery()` (a Python 2 function removed in Python 3) in the custom request filtering example, replacing it with the standard `str.split('?', 1)[0]` approach.

## Why

VCR.py supports Python 3.9+ only (per `docs/installation.rst`), but several code examples in `docs/advanced.rst` still use `import urllib2` / `urllib2.urlopen()` which raise `ModuleNotFoundError` in any Python 3 environment. The same file's `scrub_login_request` example calls `urllib.splitquery()`, which was removed from Python 3 entirely.

The compatibility list in `installation.rst` also listed `urllib2` instead of `urllib.request`.

## Changes

- `docs/advanced.rst`: 5 occurrences of `urllib2.urlopen()` → `urllib.request.urlopen()`, plus import fixes
- `docs/advanced.rst`: `urllib.splitquery(request.uri)` → `request.uri.split('?', 1)[0]`
- `docs/installation.rst`: `urllib2` → `urllib.request` in supported libraries list
- `docs/changelog.rst`: entry added as requested by CONTRIBUTING

## Verification

Changed only `.rst` documentation files — no source code touched. Verified each snippet is now valid Python 3 syntax.
