### PR TITLE
Fix stale keep-alive connection reuse; unpin werkzeug (closes #645)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ tests = [
     "aiohttp",
     "boto3",
     "cryptography",
-    "httpbin",
+    "httpbin>=0.10.3",
     "httplib2",
     "httpx",
     "httpx-curl-cffi",
@@ -52,9 +52,9 @@ tests = [
     "requests>=2.22.0",
     "tornado",
     "urllib3",
-    "werkzeug==2.0.3",
 ]
 tests-niquests = [
+    "httpbin>=0.10.3",
     "pytest",
     "pytest-aiohttp",
     "pytest-asyncio",

--- a/tests/integration/test_stale_connection.py
+++ b/tests/integration/test_stale_connection.py
@@ -1,0 +1,59 @@
+"""Regression test for reuse of a stale (server-closed) keep-alive connection.
+
+vcrpy replaces urllib3's connection classes with socketless stubs and used to
+force ``is_connection_dropped`` to always return ``False`` (a Windows playback
+fix, #116). Applied to *real* recording connections, that disabled urllib3's
+stale-connection check, so a keep-alive connection the server had already closed
+would be reused -- raising ``ProtocolError('Connection aborted', ...)`` (an
+intermittent BrokenPipe/RemoteDisconnected in CI).
+"""
+
+import socket
+import threading
+import time
+
+import urllib3
+
+import vcr
+
+
+def _keepalive_then_close_server():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(5)
+    port = sock.getsockname()[1]
+
+    def serve():
+        while True:
+            try:
+                conn, _ = sock.accept()
+            except OSError:
+                return
+            try:
+                conn.recv(65536)
+                conn.sendall(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nok",
+                )
+                # Hand the keep-alive connection back, then drop it server-side,
+                # leaving the client with a pooled-but-dead socket.
+                time.sleep(0.02)
+                conn.close()
+            except OSError:
+                pass
+
+    threading.Thread(target=serve, daemon=True).start()
+    return sock, port
+
+
+def test_stale_pooled_connection_is_not_reused(tmpdir):
+    server_sock, port = _keepalive_then_close_server()
+    try:
+        pool = urllib3.HTTPConnectionPool("127.0.0.1", port, maxsize=1)
+        with vcr.use_cassette(str(tmpdir.join("stale.yml"))):
+            pool.urlopen("GET", "/", retries=False, preload_content=True)
+            time.sleep(0.25)  # let the server's close land on the pooled socket
+            response = pool.urlopen("GET", "/", retries=False, preload_content=True)
+            assert response.status == 200
+    finally:
+        server_sock.close()

--- a/vcr/patch.py
+++ b/vcr/patch.py
@@ -480,11 +480,30 @@ class CassettePatcherBuilder:
         https_connection_remover = ConnectionRemover(
             self._get_cassette_subclass(stubs.VCRRequestsHTTPSConnection),
         )
+
+        real_is_connection_dropped = cpool.is_connection_dropped
+
+        def is_connection_dropped(connection):
+            # vcrpy swaps urllib3's connection classes for socketless stubs.
+            # During playback a stub has no live socket, so urllib3's normal
+            # check would treat it as dropped and discard it -- originally a
+            # Windows playback fix (#116). But a stub that is *recording* wraps a
+            # real connection, and we must still run urllib3's real check against
+            # that underlying connection. Otherwise urllib3 reuses a keep-alive
+            # connection the server has already closed and raises a "Connection
+            # aborted" ProtocolError (the intermittent BrokenPipe in CI).
+            real_connection = getattr(connection, "real_connection", None)
+            if real_connection is None:
+                return real_is_connection_dropped(connection)
+            if getattr(real_connection, "sock", None) is None:
+                return False
+            return real_is_connection_dropped(real_connection)
+
         mock_triples = (
             (conn, "VerifiedHTTPSConnection", stubs.VCRRequestsHTTPSConnection),
             (conn, "HTTPConnection", stubs.VCRRequestsHTTPConnection),
             (conn, "HTTPSConnection", stubs.VCRRequestsHTTPSConnection),
-            (cpool, "is_connection_dropped", mock.Mock(return_value=False)),  # Needed on Windows only
+            (cpool, "is_connection_dropped", is_connection_dropped),
             (cpool.HTTPConnectionPool, "ConnectionCls", stubs.VCRRequestsHTTPConnection),
             (cpool.HTTPSConnectionPool, "ConnectionCls", stubs.VCRRequestsHTTPSConnection),
         )


### PR DESCRIPTION
- Fix reuse of stale keep-alive connections during recording: vcrpy forced urllib3's `is_connection_dropped` to always return `False` (a 2014 Windows playback fix, #116), which let recording connections reuse a server-closed socket and raise `ProtocolError('Connection aborted', ...)`. Now scoped to playback stubs only.
- Add a regression test for the above (`tests/integration/test_stale_connection.py`).
- Drop the `werkzeug==2.0.3` pin and require `httpbin>=0.10.3` in both test extras, now that httpbin 0.10.3 fixes its `/bytes` endpoint to return `bytes` instead of `bytearray`. Closes #645.
