### PR TITLE
Extend body filtering to handle non-POST methods

### DIFF
--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -4,11 +4,14 @@ import zlib
 from io import BytesIO
 from unittest import mock
 
+import pytest
+
 from vcr.filters import (
     decode_response,
     remove_headers,
     remove_post_data_parameters,
     remove_query_parameters,
+    replace_body_parameters,
     replace_headers,
     replace_post_data_parameters,
     replace_query_parameters,
@@ -114,7 +117,8 @@ def test_remove_query_parameters():
     assert request.uri == "http://g.com/?q=cowboys"
 
 
-def test_replace_post_data_parameters():
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
+def test_replace_body_parameters_form_encoded(method):
     # This tests all of:
     #   1. keeping a parameter
     #   2. removing a parameter
@@ -123,8 +127,8 @@ def test_replace_post_data_parameters():
     #   5. removing a parameter using a callable
     #   6. replacing a parameter that doesn't exist
     body = b"one=keep&two=lose&three=change&four=shout&five=whisper"
-    request = Request("POST", "http://google.com", body, {})
-    replace_post_data_parameters(
+    request = Request(method, "http://google.com", body, {})
+    replace_body_parameters(
         request,
         [
             ("two", None),
@@ -137,46 +141,47 @@ def test_replace_post_data_parameters():
     assert request.body == b"one=keep&three=tada&four=SHOUT"
 
 
-def test_replace_post_data_parameters_empty_body():
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH"])
+def test_replace_body_parameters_form_encoded_empty_body(method):
     # This test ensures replace_post_data_parameters doesn't throw exception when body is empty.
-    body = None
-    request = Request("POST", "http://google.com", body, {})
-    replace_post_data_parameters(
+    request = Request(method, "http://google.com", None, {})
+    replace_body_parameters(
         request,
         [
             ("two", None),
             ("three", "tada"),
-            ("four", lambda key, value, request: value.upper()),
-            ("five", lambda key, value, request: None),
-            ("six", "doesntexist"),
         ],
     )
     assert request.body is None
 
 
-def test_remove_post_data_parameters():
-    # Test the backward-compatible API wrapper.
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH"])
+def test_remove_body_parameters_form_encoded(method):
     body = b"id=secret&foo=bar"
-    request = Request("POST", "http://google.com", body, {})
-    remove_post_data_parameters(request, ["id"])
+    request = Request(method, "http://google.com", body, {})
+    replacements = [("id", None)]
+    replace_body_parameters(request, replacements)
     assert request.body == b"foo=bar"
 
 
-def test_preserve_multiple_post_data_parameters():
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH"])
+def test_preserve_multiple_body_parameters(method):
     body = b"id=secret&foo=bar&foo=baz"
-    request = Request("POST", "http://google.com", body, {})
-    replace_post_data_parameters(request, [("id", None)])
+    request = Request(method, "http://google.com", body, {})
+    replace_body_parameters(request, [("id", None)])
     assert request.body == b"foo=bar&foo=baz"
 
 
-def test_remove_all_post_data_parameters():
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH"])
+def test_remove_all_body_parameters_form_encoded(method):
     body = b"id=secret&foo=bar"
-    request = Request("POST", "http://google.com", body, {})
-    replace_post_data_parameters(request, [("id", None), ("foo", None)])
+    request = Request(method, "http://google.com", body, {})
+    replace_body_parameters(request, [("id", None), ("foo", None)])
     assert request.body == b""
 
 
-def test_replace_json_post_data_parameters():
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH"])
+def test_replace_body_parameters_json(method):
     # This tests all of:
     #   1. keeping a parameter
     #   2. removing a parameter
@@ -185,9 +190,9 @@ def test_replace_json_post_data_parameters():
     #   5. removing a parameter using a callable
     #   6. replacing a parameter that doesn't exist
     body = b'{"one": "keep", "two": "lose", "three": "change", "four": "shout", "five": "whisper"}'
-    request = Request("POST", "http://google.com", body, {})
+    request = Request(method, "http://google.com", body, {})
     request.headers["Content-Type"] = "application/json"
-    replace_post_data_parameters(
+    replace_body_parameters(
         request,
         [
             ("two", None),
@@ -202,26 +207,28 @@ def test_replace_json_post_data_parameters():
     assert request_data == expected_data
 
 
-def test_remove_json_post_data_parameters():
-    # Test the backward-compatible API wrapper.
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH"])
+def test_remove_body_parameters_json(method):
     body = b'{"id": "secret", "foo": "bar", "baz": "qux"}'
-    request = Request("POST", "http://google.com", body, {})
+    request = Request(method, "http://google.com", body, {})
     request.headers["Content-Type"] = "application/json"
-    remove_post_data_parameters(request, ["id"])
+    replace_body_parameters(request, [("id", None)])
     request_body_json = json.loads(request.body)
     expected_json = json.loads(b'{"foo": "bar", "baz": "qux"}')
     assert request_body_json == expected_json
 
 
-def test_remove_all_json_post_data_parameters():
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH"])
+def test_remove_all_body_parameters_json(method):
     body = b'{"id": "secret", "foo": "bar"}'
-    request = Request("POST", "http://google.com", body, {})
+    request = Request(method, "http://google.com", body, {})
     request.headers["Content-Type"] = "application/json"
-    replace_post_data_parameters(request, [("id", None), ("foo", None)])
+    replace_body_parameters(request, [("id", None), ("foo", None)])
     assert request.body == b"{}"
 
 
-def test_replace_dict_post_data_parameters():
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH"])
+def test_replace_body_parameters_dict(method):
     # This tests all of:
     #   1. keeping a parameter
     #   2. removing a parameter
@@ -230,9 +237,9 @@ def test_replace_dict_post_data_parameters():
     #   5. removing a parameter using a callable
     #   6. replacing a parameter that doesn't exist
     body = {"one": "keep", "two": "lose", "three": "change", "four": "shout", "five": "whisper"}
-    request = Request("POST", "http://google.com", body, {})
+    request = Request(method, "http://google.com", body, {})
     request.headers["Content-Type"] = "application/x-www-form-urlencoded"
-    replace_post_data_parameters(
+    replace_body_parameters(
         request,
         [
             ("two", None),
@@ -246,22 +253,54 @@ def test_replace_dict_post_data_parameters():
     assert request.body == expected_data
 
 
-def test_remove_dict_post_data_parameters():
-    # Test the backward-compatible API wrapper.
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH"])
+def test_remove_body_parameters_dict(method):
     body = {"id": "secret", "foo": "bar", "baz": "qux"}
-    request = Request("POST", "http://google.com", body, {})
+    request = Request(method, "http://google.com", body, {})
     request.headers["Content-Type"] = "application/x-www-form-urlencoded"
-    remove_post_data_parameters(request, ["id"])
+    replace_body_parameters(request, [("id", None)])
     expected_data = {"foo": "bar", "baz": "qux"}
     assert request.body == expected_data
 
 
-def test_remove_all_dict_post_data_parameters():
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH"])
+def test_remove_all_body_parameters_dict(method):
     body = {"id": "secret", "foo": "bar"}
-    request = Request("POST", "http://google.com", body, {})
+    request = Request(method, "http://google.com", body, {})
     request.headers["Content-Type"] = "application/x-www-form-urlencoded"
-    replace_post_data_parameters(request, [("id", None), ("foo", None)])
+    replace_body_parameters(request, [("id", None), ("foo", None)])
     assert request.body == {}
+
+
+def test_replace_post_data_parameters_delegates_for_post():
+    # Test the backward-compatible API wrapper.
+    body = b"one=keep&two=lose&three=change"
+    request = Request("POST", "http://google.com", body, {})
+    replace_post_data_parameters(
+        request,
+        [
+            ("two", None),
+            ("three", "tada"),
+        ],
+    )
+    assert request.body == b"one=keep&three=tada"
+
+
+@pytest.mark.parametrize("method", ["PUT", "PATCH", "DELETE", "OPTIONS"])
+def test_replace_post_data_parameters_ignores_non_post(method):
+    # Test the backward-compatible API wrapper.
+    body = b"one=keep&two=lose"
+    request = Request(method, "http://google.com", body, {})
+    replace_post_data_parameters(request, [("two", None)])
+    assert request.body == b"one=keep&two=lose"
+
+
+def test_remove_post_data_parameters():
+    # Test the backward-compatible API wrapper.
+    body = b"id=secret&foo=bar"
+    request = Request("POST", "http://google.com", body, {})
+    remove_post_data_parameters(request, ["id"])
+    assert request.body == b"foo=bar"
 
 
 def test_decode_response_uncompressed():

--- a/vcr/config.py
+++ b/vcr/config.py
@@ -208,7 +208,7 @@ class VCR:
         if filter_post_data_parameters:
             replacements = [p if isinstance(p, tuple) else (p, None) for p in filter_post_data_parameters]
             filter_functions.append(
-                functools.partial(filters.replace_post_data_parameters, replacements=replacements),
+                functools.partial(filters.replace_body_parameters, replacements=replacements),
             )
 
         hosts_to_ignore = set(ignore_hosts)

--- a/vcr/filters.py
+++ b/vcr/filters.py
@@ -112,8 +112,8 @@ def remove_query_parameters(request, query_parameters_to_remove):
     return replace_query_parameters(request, replacements)
 
 
-def replace_post_data_parameters(request, replacements):
-    """Replace post data in request--either form data or json--according to replacements.
+def replace_body_parameters(request, replacements):
+    """Replace body parameters in request--either form data or json--according to replacements.
 
     The replacements should be a list of (key, value) pairs where the value can be any of:
       1. A simple replacement string value.
@@ -125,48 +125,61 @@ def replace_post_data_parameters(request, replacements):
         # Nothing to replace
         return request
 
+    if isinstance(request.body, BytesIO):
+        return request
+
     replacements = dict(replacements)
-    if request.method == "POST" and not isinstance(request.body, BytesIO):
-        if isinstance(request.body, dict):
-            new_body = request.body.copy()
-            for k, rv in replacements.items():
-                if k in new_body:
-                    ov = new_body.pop(k)
-                    if callable(rv):
-                        rv = rv(key=k, value=ov, request=request)
-                    if rv is not None:
-                        new_body[k] = rv
-            request.body = new_body
-        elif request.headers.get("Content-Type") == "application/json":
-            json_data = json.loads(request.body)
-            for k, rv in replacements.items():
-                if k in json_data:
-                    ov = json_data.pop(k)
-                    if callable(rv):
-                        rv = rv(key=k, value=ov, request=request)
-                    if rv is not None:
-                        json_data[k] = rv
-            request.body = json.dumps(json_data).encode("utf-8")
-        else:
-            if isinstance(request.body, str):
-                request.body = request.body.encode("utf-8")
-            splits = [p.partition(b"=") for p in request.body.split(b"&")]
-            new_splits = []
-            for k, sep, ov in splits:
-                if sep is None:
+
+    if isinstance(request.body, dict):
+        new_body = request.body.copy()
+        for k, rv in replacements.items():
+            if k in new_body:
+                ov = new_body.pop(k)
+                if callable(rv):
+                    rv = rv(key=k, value=ov, request=request)
+                if rv is not None:
+                    new_body[k] = rv
+        request.body = new_body
+    elif request.headers.get("Content-Type") == "application/json":
+        json_data = json.loads(request.body)
+        for k, rv in replacements.items():
+            if k in json_data:
+                ov = json_data.pop(k)
+                if callable(rv):
+                    rv = rv(key=k, value=ov, request=request)
+                if rv is not None:
+                    json_data[k] = rv
+        request.body = json.dumps(json_data).encode("utf-8")
+    else:
+        if isinstance(request.body, str):
+            request.body = request.body.encode("utf-8")
+        splits = [p.partition(b"=") for p in request.body.split(b"&")]
+        new_splits = []
+        for k, sep, ov in splits:
+            if sep is None:
+                new_splits.append((k, sep, ov))
+            else:
+                rk = k.decode("utf-8")
+                if rk not in replacements:
                     new_splits.append((k, sep, ov))
                 else:
-                    rk = k.decode("utf-8")
-                    if rk not in replacements:
-                        new_splits.append((k, sep, ov))
-                    else:
-                        rv = replacements[rk]
-                        if callable(rv):
-                            rv = rv(key=rk, value=ov.decode("utf-8"), request=request)
-                        if rv is not None:
-                            new_splits.append((k, sep, rv.encode("utf-8")))
-            request.body = b"&".join(k if sep is None else b"".join([k, sep, v]) for k, sep, v in new_splits)
+                    rv = replacements[rk]
+                    if callable(rv):
+                        rv = rv(key=rk, value=ov.decode("utf-8"), request=request)
+                    if rv is not None:
+                        new_splits.append((k, sep, rv.encode("utf-8")))
+        request.body = b"&".join(k if sep is None else b"".join([k, sep, v]) for k, sep, v in new_splits)
     return request
+
+
+def replace_post_data_parameters(request, replacements):
+    """
+    Wrap replace_body_parameters() for API backward compatibility.
+    """
+    if request.method != "POST":
+        return request
+
+    return replace_body_parameters(request, replacements)
 
 
 def remove_post_data_parameters(request, post_data_parameters_to_remove):


### PR DESCRIPTION
Should solve #328. 

It's also a potential breaking change if users aren't expecting requests that are not POSTs to be filtered.

If this is a big problem, an idea that I had was to add an optional parameter to `replace_body_parameters` that contains a tuple of methods to be filtered by, that way we could keep only "POST" by default and let users extend it or set it as None (no method check) if they want to.

Used a local llm to help me refactor the tests.