### PR TITLE
fix: show descriptive error when cassette contains unsupported YAML tags

### DIFF
--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -30,11 +30,35 @@ def test_deserialize_yaml_cassette_does_not_execute_python_object_tags(tmpdir):
         f"_x: !!python/object/apply:os.system ['touch {marker}']\n"
         "version: 1\n"
     )
-    # The dangerous tag is rejected (surfaced as the existing old-format error)
-    # rather than executed.
+    # The dangerous tag is rejected with a ValueError rather than executed.
     with pytest.raises(ValueError):
         deserialize(malicious, yamlserializer)
     assert not marker.check(), "malicious cassette executed code during load"
+
+
+def test_deserialize_yaml_cassette_unknown_tag_gives_clear_error():
+    # A cassette with an unrecognized Python object tag (e.g. a custom class)
+    # used to raise "Your cassette files were generated in an older version of
+    # VCR", even for freshly re-recorded cassettes. It should now raise a
+    # clear, descriptive ValueError instead.
+    cassette_with_custom_tag = (
+        "interactions:\n"
+        "- request:\n"
+        "    body: !!python/object/new:some.custom.Object\n"
+        "      state: [hello]\n"
+        "    headers: {}\n"
+        "    method: GET\n"
+        "    uri: http://example.com/\n"
+        "  response:\n"
+        "    body: {string: ok}\n"
+        "    headers: {}\n"
+        "    status: {code: 200, message: OK}\n"
+        "version: 1\n"
+    )
+    with pytest.raises(ValueError, match="There was a problem loading the cassette") as excinfo:
+        deserialize(cassette_with_custom_tag, yamlserializer)
+    # The old misleading message must not appear
+    assert "older version of VCR" not in excinfo.exconly()
 
 
 def test_deserialize_yaml_cassette_allows_safe_python_tuple_and_str():

--- a/vcr/serialize.py
+++ b/vcr/serialize.py
@@ -35,10 +35,22 @@ def _warn_about_old_cassette_format():
 def deserialize(cassette_string, serializer):
     try:
         data = serializer.deserialize(cassette_string)
-    # Old cassettes used to use yaml object thingy so I have to
-    # check for some fairly stupid exceptions here
-    except (ImportError, yaml.constructor.ConstructorError):
+    except ImportError:
+        # Old cassettes used to use yaml object thingy
         _warn_about_old_cassette_format()
+    except yaml.constructor.ConstructorError as e:
+        # The cassette contains a YAML tag that VCR's safe loader does not
+        # support (e.g. a custom Python object type recorded by an older VCR
+        # version, or a non-standard type in the request/response body).
+        # Raise a descriptive error rather than the misleading "older version"
+        # message; still mention the migration script since old cassettes with
+        # Python object tags are the most common cause.
+        raise ValueError(
+            f"There was a problem loading the cassette: {e}. "
+            "If this is an old cassette, delete it and re-record, or "
+            "run the migration script. "
+            "See http://git.io/mHhLBg for more details."
+        ) from e
     if _looks_like_an_old_cassette(data):
         _warn_about_old_cassette_format()
 

--- a/vcr/serialize.py
+++ b/vcr/serialize.py
@@ -27,8 +27,7 @@ def _looks_like_an_old_cassette(data):
 def _warn_about_old_cassette_format():
     raise ValueError(
         "Your cassette files were generated in an older version "
-        "of VCR. Delete your cassettes or run the migration script."
-        "See http://git.io/mHhLBg for more details.",
+        "of VCR. Delete your cassettes or run the migration script.",
     )
 
 
@@ -43,13 +42,11 @@ def deserialize(cassette_string, serializer):
         # support (e.g. a custom Python object type recorded by an older VCR
         # version, or a non-standard type in the request/response body).
         # Raise a descriptive error rather than the misleading "older version"
-        # message; still mention the migration script since old cassettes with
-        # Python object tags are the most common cause.
+        # message; still mention the migration script for old cassette cases.
         raise ValueError(
             f"There was a problem loading the cassette: {e}. "
             "If this is an old cassette, delete it and re-record, or "
-            "run the migration script. "
-            "See http://git.io/mHhLBg for more details."
+            "run the migration script.",
         ) from e
     if _looks_like_an_old_cassette(data):
         _warn_about_old_cassette_format()


### PR DESCRIPTION
Fixes #1007.

## What changed

`vcr/serialize.py`'s `deserialize()` function caught both `ImportError` and `yaml.constructor.ConstructorError` in a single `except` clause and forwarded both to the same "Your cassette files were generated in an older version of VCR" message.

The `ConstructorError` path fires whenever the cassette contains a YAML tag that VCR's safe loader does not recognise, including `!!python/object/new:some.custom.Object` and similar tags. In that case the "older version" message can be misleading because the real problem is that the safe loader does not know how to construct that tag.

This PR splits the two exception cases into separate handlers:

- `ImportError` -> keeps the existing old-format cassette message.
- `yaml.constructor.ConstructorError` -> raises a new `ValueError` that includes the underlying unsupported-tag error and suggests deleting/re-recording or running the migration script only if the cassette is old.

The follow-up commit also removes the stale `git.io` migration link from both old-format and unsupported-tag error messages, because the short link now returns 404.

## Before

```text
ValueError: Your cassette files were generated in an older version of VCR.
Delete your cassettes or run the migration script.See http://git.io/mHhLBg for more details.
```

## After

```text
ValueError: There was a problem loading the cassette: could not determine a
constructor for the tag 'tag:yaml.org,2002:python/object/new:some.custom.Object'
  in "<unicode string>", line 3, column 11.
If this is an old cassette, delete it and re-record, or run the migration script.
```

## Tests

- Updated `test_deserialize_yaml_cassette_does_not_execute_python_object_tags` to remove the stale comment ("surfaced as the existing old-format error") — behaviour unchanged, `ValueError` is still raised, code is not executed.
- Added `test_deserialize_yaml_cassette_unknown_tag_gives_clear_error` which asserts the new message fires and the misleading "older version of VCR" string does not appear.
- Follow-up verification: `uv run --with-editable . --extra tests python -m pytest tests/unit/test_serialize.py tests/unit/test_persist.py -q` -> 22 passed.

This pull request was prepared with the assistance of AI, under my direction and review.