### PR TITLE
disallow saving invalid casettes

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -90,6 +90,31 @@ Finally, register your class with VCR to use your new serializer.
     with my_vcr.use_cassette('test.bogo'):
         # your http here
 
+Load cassettes containing custom Python objects
+-----------------------------------------------
+
+For security, VCR.py loads YAML cassettes with a *safe* loader that refuses
+the ``!!python/object`` family of tags (loading them could execute arbitrary
+code from an untrusted cassette). If a cassette legitimately contains a custom
+Python object, deserializing it raises a ``ValueError`` explaining that the
+loader refused to construct the object.
+
+You can teach the loader how to rebuild your object by registering a
+constructor for its tag:
+
+.. code:: python
+
+    from vcr.serializers import yamlserializer
+
+    def construct_my_object(loader, node):
+        mapping = loader.construct_mapping(node, deep=True)
+        return MyObject(**mapping)
+
+    yamlserializer.register_constructor(
+        "tag:yaml.org,2002:python/object/new:my.module.MyObject",
+        construct_my_object,
+    )
+
 Register your own request matcher
 ---------------------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,10 @@ Changelog
 
 All help in providing PRs to close out bug issues is appreciated. Even if that is providing a repo that fully replicates issues. We have very generous contributors that have added these to bug issues which meant another contributor picked up the bug and closed it out.
 
+-  Unreleased
+    - Refuse to save a cassette that embeds a Python object the safe loader could not read back, turning a silent record-now/fail-later footgun into an immediate, actionable error (#1007)
+    - Add ``vcr.serializers.yamlserializer.register_constructor`` as a public API for teaching the safe cassette loader to construct custom YAML tags (#1007)
+
 -  8.2.1
     - SECURITY: Load cassettes with a safe YAML loader, preventing arbitrary code execution when a cassette from an untrusted source is loaded (GHSA-rpj2-4hq8-938g) - thanks @RamiAltai and @EQSTLab
     - Validate ``record_mode`` and raise a clear error on an invalid value (#208)

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -1,10 +1,16 @@
+from io import BytesIO
 from unittest import mock
 
 import pytest
+import yaml
 
 from vcr.request import Request
 from vcr.serialize import deserialize, serialize
 from vcr.serializers import compat, jsonserializer, yamlserializer
+
+
+class _CustomHeader:
+    """A stand-in for a custom Python object that might end up in a header."""
 
 
 def test_deserialize_old_yaml_cassette():
@@ -35,6 +41,64 @@ def test_deserialize_yaml_cassette_does_not_execute_python_object_tags(tmpdir):
     with pytest.raises(ValueError):
         deserialize(malicious, yamlserializer)
     assert not marker.check(), "malicious cassette executed code during load"
+
+
+def test_deserialize_yaml_cassette_allows_registered_custom_constructor():
+    # Once a constructor is registered for a custom tag, the cassette loads.
+    tag = "tag:yaml.org,2002:python/object/new:some.module.CustomBody"
+    yamlserializer.register_constructor(tag, lambda loader, node: "custom-body")
+    try:
+        cassette = (
+            "interactions:\n"
+            "- request:\n"
+            "    body: !!python/object/new:some.module.CustomBody {}\n"
+            "    headers: {}\n"
+            "    method: GET\n"
+            "    uri: http://example.com/\n"
+            "  response:\n"
+            "    body: {string: ok}\n"
+            "    headers: {}\n"
+            "    status: {code: 200, message: OK}\n"
+            "version: 1\n"
+        )
+        (requests, _) = deserialize(cassette, yamlserializer)
+        assert requests[0].body == b"custom-body"
+    finally:
+        del yamlserializer._CassetteLoader.yaml_constructors[tag]
+
+
+def test_serialize_refuses_unloadable_python_object():
+    # A cassette must not be *saved* if it embeds a Python object the safe
+    # loader couldn't read back, otherwise recording succeeds but replay fails
+    request = Request(method="POST", uri="http://localhost/", headers={"X-Custom": _CustomHeader()}, body="")
+    with pytest.raises(yaml.representer.RepresenterError, match="register_constructor"):
+        serialize({"requests": [request], "responses": [{}]}, yamlserializer)
+
+
+def test_serialize_allows_registered_python_object():
+    # If a constructor is registered for the object's tag, the loader can read
+    # it back, so saving it is allowed too (the two sides stay symmetric).
+    tag = f"tag:yaml.org,2002:python/object:{_CustomHeader.__module__}.{_CustomHeader.__qualname__}"
+    yamlserializer.register_constructor(tag, lambda loader, node: _CustomHeader())
+    try:
+        request = Request(
+            method="POST",
+            uri="http://localhost/",
+            headers={"X-Custom": _CustomHeader()},
+            body="",
+        )
+        serialize({"requests": [request], "responses": [{}]}, yamlserializer)
+    finally:
+        del yamlserializer._CassetteLoader.yaml_constructors[tag]
+
+
+def test_serialize_allows_bytesio_body_and_round_trips():
+    # A BytesIO body uses a tag the loader knows about, so it must serialize
+    # without tripping the guard and load back to the same bytes.
+    request = Request(method="POST", uri="http://localhost/", body=BytesIO(b"payload"), headers={})
+    cassette = serialize({"requests": [request], "responses": [{}]}, yamlserializer)
+    (requests, _) = deserialize(cassette, yamlserializer)
+    assert requests[0].body.read() == b"payload"
 
 
 def test_deserialize_yaml_cassette_allows_safe_python_tuple_and_str():

--- a/vcr/serializers/yamlserializer.py
+++ b/vcr/serializers/yamlserializer.py
@@ -4,10 +4,10 @@ import yaml
 
 # Use the libYAML versions if possible
 try:
-    from yaml import CDumper as Dumper
+    from yaml import CDumper as _BaseDumper
     from yaml import CSafeLoader as _BaseLoader
 except ImportError:
-    from yaml import Dumper
+    from yaml import Dumper as _BaseDumper
     from yaml import SafeLoader as _BaseLoader
 
 
@@ -27,6 +27,41 @@ class _CassetteLoader(_BaseLoader):
     invokes PyYAML's generic object machinery, so it cannot be used to
     instantiate an arbitrary class.
     """
+
+
+class _CassetteDumper(_BaseDumper):
+    """A YAML dumper that refuses to emit what the cassette loader can't read.
+
+    Serializing with PyYAML's full dumper happily turns any Python object into
+    a ``!!python/object``/``!!python/object/new``/``!!python/name`` tag. The
+    cassette loader, being a *safe* loader, refuses those tags unless a
+    constructor has been registered for them. Left unchecked, recording such a
+    cassette would succeed and then fail to load later with a confusing error
+    (see issue #1007).
+
+    This dumper closes that gap: if it is about to emit a Python-specific tag
+    that the loader has no constructor for, it raises immediately so the
+    cassette is never written. The check uses the loader's own constructor
+    table, so any tag made loadable via :func:`register_constructor` is also
+    made dumpable, keeping the two sides symmetric.
+    """
+
+    def represent_data(self, data):
+        node = super().represent_data(data)
+        tag = node.tag
+        if (
+            isinstance(tag, str)
+            and tag.startswith("tag:yaml.org,2002:python/")
+            and tag not in _CassetteLoader.yaml_constructors
+        ):
+            raise yaml.representer.RepresenterError(
+                "vcr refused to save the cassette because it contains a Python "
+                f"object the safe loader could not read back ({tag!r}). Keep "
+                "custom Python objects out of the recorded request/response, or "
+                "register a constructor for the tag with "
+                "vcr.serializers.yamlserializer.register_constructor(tag, constructor).",
+            )
+        return node
 
 
 def _construct_python_str(loader, node):
@@ -67,9 +102,20 @@ _CassetteLoader.add_constructor("tag:yaml.org,2002:python/object/new:_io.BytesIO
 _CassetteLoader.add_constructor("tag:yaml.org,2002:python/object/apply:builtins.iter", _construct_iter)
 
 
+def register_constructor(tag, constructor):
+    """Teach the cassette loader how to build a custom YAML tag.
+
+    The cassette loader is a *safe* loader: for security it refuses the
+    ``!!python/object`` family of tags by default. If your cassettes
+    legitimately contain a custom Python object, register a constructor for
+    its tag so the loader can rebuild it instead of raising an error.
+    """
+    _CassetteLoader.add_constructor(tag, constructor)
+
+
 def deserialize(cassette_string):
     return yaml.load(cassette_string, Loader=_CassetteLoader)
 
 
 def serialize(cassette_dict):
-    return yaml.dump(cassette_dict, Dumper=Dumper)
+    return yaml.dump(cassette_dict, Dumper=_CassetteDumper)


### PR DESCRIPTION
Related to https://github.com/kevin1024/vcrpy/issues/1007#issuecomment-4809579524
This create a safe dumper to match the safe loader,to avoid save casettes that can't be read. It also add a method `register_constructor `to allow python objects in both, serialization and deserialization.

Another option, instead of `register_constructor` is to create a function that call: `_CassetteDumper.add_representer(class_name,  some_callable)` or `add_multi_representer`, where the callable receive the dumper and the data and expect a valid yaml.Node. If you want @kevin1024,  I can change the PR on that direction.