### PR TITLE
fix(aiohttp): restore raw response headers

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,9 @@ Changelog
 
 All help in providing PRs to close out bug issues is appreciated. Even if that is providing a repo that fully replicates issues. We have very generous contributors that have added these to bug issues which meant another contributor picked up the bug and closed it out.
 
+-  Unreleased
+    - Restore ``aiohttp.ClientResponse.raw_headers`` on replayed responses, including repeated headers (#1034) - thanks @HostX0
+
 -  8.3.0
     - Add support for niquests (#980) - thanks @ionelmc
     - Refuse to record a cassette containing a Python object the safe YAML loader could not read back, so recording fails fast instead of producing a cassette that breaks on replay (#1007, #1009) - thanks @Polandia94

--- a/tests/integration/test_aiohttp.py
+++ b/tests/integration/test_aiohttp.py
@@ -8,6 +8,8 @@ import pytest_httpbin.certs
 import yarl
 
 import vcr
+from vcr.request import Request
+from vcr.stubs.aiohttp_stubs import build_response
 
 asyncio = pytest.importorskip("asyncio")
 aiohttp = pytest.importorskip("aiohttp")
@@ -69,6 +71,23 @@ def test_headers(tmpdir, auth, httpbin):
         assert cassette.play_count == 1
         assert "istr" not in cassette.data[0]
         assert "yarl.URL" not in cassette.data[0]
+
+
+def test_replayed_response_exposes_raw_headers():
+    vcr_request = Request("GET", "https://example.com", None, {})
+    vcr_response = {
+        "status": {"code": 200, "message": "OK"},
+        "headers": {"Content-Type": ["text/plain"], "X-Repeated": ["first", "second"]},
+        "body": {"string": b"response"},
+    }
+
+    response = build_response(vcr_request, vcr_response, [])
+
+    assert response.raw_headers == (
+        (b"Content-Type", b"text/plain"),
+        (b"X-Repeated", b"first"),
+        (b"X-Repeated", b"second"),
+    )
 
 
 @pytest.mark.online

--- a/vcr/stubs/aiohttp_stubs.py
+++ b/vcr/stubs/aiohttp_stubs.py
@@ -97,6 +97,13 @@ def build_response(vcr_request, vcr_response, history):
     response._body = vcr_response["body"].get("string", b"")
     response.reason = vcr_response["status"]["message"]
     response._headers = _deserialize_headers(vcr_response["headers"])
+    response._raw_headers = tuple(
+        (
+            name.encode("utf-8", "surrogateescape"),
+            value.encode("utf-8", "surrogateescape"),
+        )
+        for name, value in response._headers.items()
+    )
     response._history = tuple(history)
     # cookies
     for hdr in response.headers.getall(hdrs.SET_COOKIE, ()):


### PR DESCRIPTION
Fixes #970.

## Summary

- populate `ClientResponse.raw_headers` for replayed aiohttp responses
- preserve repeated header fields and cassette order
- encode the restored byte view with aiohttp-compatible UTF-8 `surrogateescape`
- add an offline regression test and the required changelog credit

## Root cause

`build_response()` rebuilt `_headers` from the cassette but left `_raw_headers` at aiohttp's default `None`. Consumers that use the raw byte header API therefore behaved differently under replay than against a real response.

## Verification

On the current head with Python 3.12 and aiohttp 3.14.3:

- `.venv/bin/pytest -q tests/integration/test_aiohttp.py -m 'not online'` — 8 passed, 22 deselected
- `.venv/bin/ruff check vcr/stubs/aiohttp_stubs.py tests/integration/test_aiohttp.py` — passed
- `.venv/bin/ruff format --check vcr/stubs/aiohttp_stubs.py tests/integration/test_aiohttp.py` — passed
- `git diff --check` — passed
